### PR TITLE
Adding datasource for nomad_deployment resource

### DIFF
--- a/nomad/data_source_deployment.go
+++ b/nomad/data_source_deployment.go
@@ -1,0 +1,142 @@
+package nomad
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceDeployment() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDeploymentRead,
+		Schema: map[string]*schema.Schema{
+
+			"id": {
+				Description: "Deployment ID",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			// computed attributes
+			"namepsace": {
+				Description: "Deployment Namespace",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"job_id": {
+				Description: "Job ID",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"job_version": {
+				Description: "Job Version",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"job_create_index": {
+				Description: "Job Create Index",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"job_modify_index": {
+				Description: "Job Modify Index",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"task_groups": {
+				Description: "Task Groups",
+				Computed:    true,
+				Type:        schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"placed_canaries": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"auto_revert": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"promoted": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"desired_canaries": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"desired_total": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"placed_alloc": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"healthy_alloc": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"unhealthy_alloc": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"status": {
+				Description: "Deployment Status",
+				Computed:    true,
+				Type:        schema.TypeString,
+			},
+			"status_description": {
+				Description: "Deployment Status Description",
+				Computed:    true,
+				Type:        schema.TypeString,
+			},
+			"create_index": {
+				Description: "Create Index",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"modify_index": {
+				Description: "Modify Index",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceDeploymentRead(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(ProviderConfig)
+	client := providerConfig.client
+
+	id := d.Get("id").(string)
+	log.Printf("[DEBUG] Getting deployment status: %q", id)
+	deployment, _, err := client.Deployments().Info(id, nil)
+	if err != nil {
+		// As of Nomad 0.4.1, the API client returns an error for 404
+		// rather than a nil result, so we must check this way.
+		if strings.Contains(err.Error(), "404") {
+			return err
+		}
+
+		return fmt.Errorf("error checking for deployment: %#v", err)
+	}
+
+	d.SetId(deployment.ID)
+	d.Set("namespace", deployment.Namespace)
+	d.Set("job_id", deployment.JobID)
+	d.Set("job_version", deployment.JobVersion)
+	d.Set("job_create_index", deployment.JobCreateIndex)
+	d.Set("job_modify_index", deployment.JobModifyIndex)
+	d.Set("task_groups", deployment.TaskGroups)
+	d.Set("status", deployment.Status)
+	d.Set("status_description", deployment.StatusDescription)
+	d.Set("create_index", deployment.CreateIndex)
+	d.Set("modify_index", deployment.ModifyIndex)
+
+	return nil
+}

--- a/nomad/data_source_deployment.go
+++ b/nomad/data_source_deployment.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func dataSourceDeployment() *schema.Resource {

--- a/nomad/data_source_deployment.go
+++ b/nomad/data_source_deployment.go
@@ -13,13 +13,13 @@ func dataSourceDeployment() *schema.Resource {
 		Read: dataSourceDeploymentRead,
 		Schema: map[string]*schema.Schema{
 
-			"id": {
+			"deployment_id": {
 				Description: "Deployment ID",
 				Type:        schema.TypeString,
 				Required:    true,
 			},
 			// computed attributes
-			"namepsace": {
+			"namespace": {
 				Description: "Deployment Namespace",
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -47,40 +47,40 @@ func dataSourceDeployment() *schema.Resource {
 			"task_groups": {
 				Description: "Task Groups",
 				Computed:    true,
-				Type:        schema.TypeList,
+				Type:        schema.TypeMap,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"placed_canaries": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Computed: true,
 						},
 						"auto_revert": {
 							Type:     schema.TypeBool,
-							Optional: true,
+							Computed: true,
 						},
 						"promoted": {
 							Type:     schema.TypeBool,
-							Optional: true,
+							Computed: true,
 						},
 						"desired_canaries": {
 							Type:     schema.TypeInt,
-							Optional: true,
+							Computed: true,
 						},
 						"desired_total": {
 							Type:     schema.TypeInt,
-							Optional: true,
+							Computed: true,
 						},
 						"placed_alloc": {
 							Type:     schema.TypeInt,
-							Optional: true,
+							Computed: true,
 						},
 						"healthy_alloc": {
 							Type:     schema.TypeInt,
-							Optional: true,
+							Computed: true,
 						},
 						"unhealthy_alloc": {
 							Type:     schema.TypeInt,
-							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -113,7 +113,7 @@ func dataSourceDeploymentRead(d *schema.ResourceData, meta interface{}) error {
 	providerConfig := meta.(ProviderConfig)
 	client := providerConfig.client
 
-	id := d.Get("id").(string)
+	id := d.Get("deployment_id").(string)
 	log.Printf("[DEBUG] Getting deployment status: %q", id)
 	deployment, _, err := client.Deployments().Info(id, nil)
 	if err != nil {

--- a/nomad/data_source_deployment_test.go
+++ b/nomad/data_source_deployment_test.go
@@ -1,0 +1,119 @@
+package nomad
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccNomadJob_Basic(t *testing.T) {
+	var testDeployment api.Deployment
+	deploymentId := acctest.RandString(8)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckNomadDeploymentFail,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckNomadDeploymentConfig_basic(deploymentId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNomadDeploymentExists("nomad_deployment.foobar", &testDeployment),
+				),
+			},
+			{
+				Config: testAccCheckNomadDeploymentConfig_basic(deploymentId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.nomad_deployment.foobar", "id", fmt.Sprintf("%s", deploymentId)),
+				),
+			},
+			{
+				Config:      testAccCheckNomadDeploymentConfig_nonexisting(deploymentId),
+				Destroy:     false,
+				ExpectError: regexp.MustCompile(`.*no deployment found with that id`),
+			},
+		},
+	})
+}
+
+func testAccCheckNomadDeploymentExists(n string, deployment *api.Deployment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Deployment ID is set")
+		}
+
+		providerConfig := testProvider.Meta().(ProviderConfig)
+		client := providerConfig.client
+
+		id := rs.Primary.ID
+
+		// Try to find the deployment
+		test_deployment, _, err := client.Deployments().Info(id, nil)
+
+		if err != nil {
+			return err
+		}
+
+		if test_deployment.ID != rs.Primary.ID {
+			return fmt.Errorf("Deployment not found")
+		}
+
+		*deployment = *test_deployment
+
+		return nil
+	}
+}
+
+func testAccCheckNomadDeploymentFail(s *terraform.State) error {
+	providerConfig := testProvider.Meta().(ProviderConfig)
+	client := providerConfig.client
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "nomad_deployment" {
+			continue
+		}
+
+		id := rs.Primary.ID
+
+		// Try to find the Droplet
+		_, _, err := client.Deployments().Info(id, nil)
+
+		// Wait
+
+		if err != nil && !strings.Contains(err.Error(), "404") {
+			return fmt.Errorf(
+				"Error waiting for deployment (%s) to fail: %s",
+				rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckNomadDeploymentConfig_basic(str string) string {
+	return fmt.Sprintf(`
+data "nomad_deployment" "foobar" {
+  id               = "%s"
+}
+`, str)
+}
+
+func testAccCheckNomadDeploymentConfig_nonexisting(str string) string {
+	return fmt.Sprintf(`
+data "nomad_deployment" "foobar" {
+  id               = "%s-nonexisting"
+}
+`, str)
+}

--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -69,6 +69,7 @@ func Provider() terraform.ResourceProvider {
 			"nomad_acl_token":   dataSourceACLToken(),
 			"nomad_acl_tokens":  dataSourceACLTokens(),
 			"nomad_deployments": dataSourceDeployments(),
+			"nomad_deployment":  dataSourceDeployment(),
 			"nomad_job":         dataSourceJob(),
 			"nomad_job_parser":  dataSourceJobParser(),
 			"nomad_namespace":   dataSourceNamespace(),

--- a/website/docs/d/deployment.html.markdown
+++ b/website/docs/d/deployment.html.markdown
@@ -15,11 +15,11 @@ An error is triggered if zero or more than one result is returned by the query.
 
 ## Example Usage
 
-Get the data about a snapshot:
+Get the data about a deployment:
 
 ```hcl
 data "nomad_deployment" "example1" {
-  id = "example_deployment"
+  deployment_id = "70638f62-5c19-193e-30d6-f9d6e689ab8e"
 }
 ```
 
@@ -27,19 +27,19 @@ data "nomad_deployment" "example1" {
 
 The following arguments are supported:
 
-* `id` - The ID of the deployment.
+* `deployment_id`: `string` The ID of the deployment.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `namespace`: Namespace of the deployment.
-* `job_id`: ID of the job.
-* `job_version`: Job version.
-* `job_create_index`: Job creation index.
-* `job_modify_index`: Job modification index.
-* `task_groups`: Task Groups.
-* `status`: Deployment status.
-* `status_description`: Deployment Status Description.
-* `create_index`: Deployment creation date.
-* `modify_index`: Deployment modification date.
+* `namespace`: `string` Namespace of the deployment.
+* `job_id`: `string` ID of the job.
+* `job_version`: `string` Job version.
+* `job_create_index`: `integer` Job creation index.
+* `job_modify_index`: `integer` Job modification index.
+* `task_groups`: `map` Task Groups.
+* `status`: `string` Deployment status.
+* `status_description`: `string` Deployment Status Description.
+* `create_index`: `integer` Deployment creation date.
+* `modify_index`: `integer` Deployment modification date.

--- a/website/docs/d/deployment.html.markdown
+++ b/website/docs/d/deployment.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_deployment"
+sidebar_current: "docs-nomad-datasource-deployment"
+description: |-
+  Get information on an deployment.
+---
+
+# nomad_deployment
+
+Get information on an deployment ID. The aim of this datasource is to enable
+you to act on various settings and states of a particular deployment.
+
+An error is triggered if zero or more than one result is returned by the query.
+
+## Example Usage
+
+Get the data about a snapshot:
+
+```hcl
+data "nomad_deployment" "example1" {
+  id = "example_deployment"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - The ID of the deployment.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `namespace`: Namespace of the deployment.
+* `job_id`: ID of the job.
+* `job_version`: Job version.
+* `job_create_index`: Job creation index.
+* `job_modify_index`: Job modification index.
+* `task_groups`: Task Groups.
+* `status`: Deployment status.
+* `status_description`: Deployment Status Description.
+* `create_index`: Deployment creation date.
+* `modify_index`: Deployment modification date.

--- a/website/nomad.erb
+++ b/website/nomad.erb
@@ -22,6 +22,9 @@
             <li<%= sidebar_current("docs-nomad-datasource-acl-tokens") %>>
               <a href="/docs/providers/nomad/d/acl_tokens.html">nomad_acl_tokens</a>
             </li>
+            <li<%= sidebar_current("docs-nomad-datasource-deployment") %>>
+              <a href="/docs/providers/nomad/d/deployment.html">nomad_deployment</a>
+            </li>
             <li<%= sidebar_current("docs-nomad-datasource-deployments") %>>
               <a href="/docs/providers/nomad/d/deployments.html">nomad_deployments</a>
             </li>


### PR DESCRIPTION
This one introduces a nomad_deployment datasource which allows a user to act or respond to this resource's various attributes. Again, I've tested this in my limited environments and it works well for me, but further testing and feedback would be greatly appreciated.  I am also working on a `nomad_deployment` resource as well and will submit that PR once I've tested it a little more.