### PR TITLE
Add data source for listing datacenters

### DIFF
--- a/nomad/data_source_datacenters.go
+++ b/nomad/data_source_datacenters.go
@@ -1,0 +1,80 @@
+package nomad
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceDatacenters() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDatacentersRead,
+
+		Schema: map[string]*schema.Schema{
+			"prefix": {
+				Description: "Prefix value used for filtering results.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"ignore_down_nodes": {
+				Description: "If enabled, this flag will ignore nodes that are down when listing datacenters.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+			},
+			"datacenters": {
+				Description: "The list of datacenters.",
+				Computed:    true,
+				Type:        schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDatacentersRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(ProviderConfig).client
+	nodes, _, err := client.Nodes().List(nil)
+	if err != nil {
+		return fmt.Errorf("failed to query list of nodes: %v", err)
+	}
+
+	prefix := d.Get("prefix").(string)
+	ignoreDown := d.Get("ignore_down_nodes").(bool)
+
+	d.SetId(resource.UniqueId())
+	if err := d.Set("datacenters", filterDatacenters(nodes, prefix, ignoreDown)); err != nil {
+		return fmt.Errorf("error setting datacenters: %v", err)
+	}
+
+	return nil
+}
+
+func filterDatacenters(nodes []*api.NodeListStub, prefix string, ignoreDown bool) []string {
+	datacentersSet := make(map[string]struct{})
+	datacenters := []string{}
+
+	for _, n := range nodes {
+		ignore := n.Status == "down" && ignoreDown
+		if ignore || !strings.HasPrefix(n.Datacenter, prefix) {
+			continue
+		}
+		if _, ok := datacentersSet[n.Datacenter]; ok {
+			continue
+		}
+
+		datacentersSet[n.Datacenter] = struct{}{}
+		datacenters = append(datacenters, n.Datacenter)
+	}
+
+	// Sort output to keep it stable.
+	sort.Strings(datacenters)
+
+	return datacenters
+}

--- a/nomad/data_source_datacenters_test.go
+++ b/nomad/data_source_datacenters_test.go
@@ -1,0 +1,110 @@
+package nomad
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceDatacenters_Basic(t *testing.T) {
+	dataSourceName := "data.nomad_datacenters.dcs"
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceDataSourceDatacentersConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "datacenters.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "datacenters.0", "dc1"),
+				),
+			},
+		},
+	})
+}
+
+func TestFilterDatacenters(t *testing.T) {
+	cases := []struct {
+		name       string
+		nodes      []*api.NodeListStub
+		prefix     string
+		ignoreDown bool
+		want       []string
+	}{
+		{
+			name: "single datacenter",
+			nodes: []*api.NodeListStub{
+				&api.NodeListStub{Datacenter: "dc1"},
+			},
+			want: []string{"dc1"},
+		},
+		{
+			name: "multiple datacenters",
+			nodes: []*api.NodeListStub{
+				&api.NodeListStub{Datacenter: "dc1"},
+				&api.NodeListStub{Datacenter: "dc2"},
+			},
+			want: []string{"dc1", "dc2"},
+		},
+		{
+			name: "duplicate datacenter",
+			nodes: []*api.NodeListStub{
+				&api.NodeListStub{Datacenter: "dc1"},
+				&api.NodeListStub{Datacenter: "dc1"},
+				&api.NodeListStub{Datacenter: "dc2"},
+			},
+			want: []string{"dc1", "dc2"},
+		},
+		{
+			name: "filter down nodes",
+			nodes: []*api.NodeListStub{
+				&api.NodeListStub{Datacenter: "dc1"},
+				&api.NodeListStub{Datacenter: "dc1"},
+				&api.NodeListStub{Datacenter: "dc2", Status: "down"},
+			},
+			ignoreDown: true,
+			want:       []string{"dc1"},
+		},
+		{
+			name: "filter with prefix",
+			nodes: []*api.NodeListStub{
+				&api.NodeListStub{Datacenter: "prod-1"},
+				&api.NodeListStub{Datacenter: "prod-2"},
+				&api.NodeListStub{Datacenter: "dev"},
+			},
+			prefix: "prod",
+			want:   []string{"prod-1", "prod-2"},
+		},
+		{
+			name: "filter with prefix, empty result",
+			nodes: []*api.NodeListStub{
+				&api.NodeListStub{Datacenter: "prod-1"},
+				&api.NodeListStub{Datacenter: "prod-2"},
+				&api.NodeListStub{Datacenter: "dev"},
+			},
+			prefix: "not-there",
+			want:   []string{},
+		},
+		{
+			name:  "empty list",
+			nodes: []*api.NodeListStub{},
+			want:  []string{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := filterDatacenters(c.nodes, c.prefix, c.ignoreDown)
+
+			if diff := cmp.Diff(got, c.want); diff != "" {
+				t.Fatalf("datacenters mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+var testResourceDataSourceDatacentersConfig = `
+data "nomad_datacenters" "dcs" {}
+`

--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -69,6 +69,7 @@ func Provider() terraform.ResourceProvider {
 			"nomad_acl_policy":   dataSourceAclPolicy(),
 			"nomad_acl_token":    dataSourceACLToken(),
 			"nomad_acl_tokens":   dataSourceACLTokens(),
+			"nomad_datacenters":  dataSourceDatacenters(),
 			"nomad_deployments":  dataSourceDeployments(),
 			"nomad_job":          dataSourceJob(),
 			"nomad_job_parser":   dataSourceJobParser(),

--- a/website/docs/d/datacenters.html.md
+++ b/website/docs/d/datacenters.html.md
@@ -1,0 +1,33 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_datacenters"
+sidebar_current: "docs-nomad-datasource-datacenters"
+description: |-
+  Retrieve a list of datacenters.
+---
+
+# nomad_datacenters
+
+Retrieve a list of datacenters.
+
+## Example Usage
+
+```hcl
+data "nomad_datacenters" "datacenters" {
+  prefix            = "prod"
+  ignore_down_nodes = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `prefix` `(string)`: An optional string to filter datacenters based on name prefix. If not provided, all datacenters are returned.
+* `ignore_down_nodes` `(bool: false)`: An optional flag that, if set to `true` will ignore down nodes when compiling the list of datacenters.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `datacenters`: `list(string)` a list of datacenters.

--- a/website/nomad.erb
+++ b/website/nomad.erb
@@ -25,6 +25,9 @@
             <li<%= sidebar_current("docs-nomad-datasource-acl-tokens") %>>
               <a href="/docs/providers/nomad/d/acl_tokens.html">nomad_acl_tokens</a>
             </li>
+            <li<%= sidebar_current("docs-nomad-datasource-datacenters") %>>
+              <a href="/docs/providers/nomad/d/datacenters.html">nomad_datacenters</a>
+            </li>
             <li<%= sidebar_current("docs-nomad-datasource-deployments") %>>
               <a href="/docs/providers/nomad/d/deployments.html">nomad_deployments</a>
             </li>


### PR DESCRIPTION
This PR introduces a new data source to list datacenters in the region where the provider is configured.

```hcl
data "nomad_datacenters" "datacenters" {
  prefix            = "prod"
  ignore_down_nodes = true
}
```

An [alias](https://www.terraform.io/docs/configuration/providers.html#alias-multiple-provider-configurations) can be used for listing datacenters in multiple regions.

Closes #151 