### PR TITLE
datasource: add Nomad scheduler config data source.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ exclude (
 
 require (
 	github.com/google/go-cmp v0.5.0
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/nomad v0.12.5-0.20201029140339-d6255129a300
 	github.com/hashicorp/nomad/api v0.0.0-20201028165800-38e23b62a770

--- a/nomad/data_source_scheduler_config.go
+++ b/nomad/data_source_scheduler_config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-nomad/nomad/helper"
 )
 
 func dataSourceSchedulerConfig() *schema.Resource {
@@ -39,16 +40,14 @@ func dataSourceSchedulerConfigRead(d *schema.ResourceData, meta interface{}) err
 	// Set a unique ID, as we have nothing else to go on.
 	d.SetId(resource.UniqueId())
 
-	if err := d.Set("scheduler_algorithm", schedCfg.SchedulerConfig.SchedulerAlgorithm); err != nil {
-		return fmt.Errorf("failed to set scheduler_algorithm: %v", err)
-	}
 	premptMap := map[string]bool{
 		"batch_scheduler_enabled":   schedCfg.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled,
 		"service_scheduler_enabled": schedCfg.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled,
 		"system_scheduler_enabled":  schedCfg.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled,
 	}
-	if err := d.Set("preemption_config", premptMap); err != nil {
-		return fmt.Errorf("failed to set preemption_config: %v", err)
-	}
-	return nil
+
+	sw := helper.NewStateWriter(d)
+	sw.Set("scheduler_algorithm", schedCfg.SchedulerConfig.SchedulerAlgorithm)
+	sw.Set("preemption_config", premptMap)
+	return sw.Error()
 }

--- a/nomad/data_source_scheduler_config.go
+++ b/nomad/data_source_scheduler_config.go
@@ -1,0 +1,54 @@
+package nomad
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceSchedulerConfig() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceSchedulerConfigRead,
+
+		Schema: map[string]*schema.Schema{
+			"scheduler_algorithm": {
+				Description: "Specifies whether scheduler binpacks or spreads allocations on available nodes.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"preemption_config": {
+				Description: "Options to enable preemption for various schedulers.",
+				Computed:    true,
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeBool},
+			},
+		},
+	}
+}
+
+func dataSourceSchedulerConfigRead(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(ProviderConfig).client
+
+	schedCfg, _, err := client.Operator().SchedulerGetConfiguration(nil)
+	if err != nil {
+		return fmt.Errorf("failed to query scheduler config: %v", err)
+	}
+
+	// Set a unique ID, as we have nothing else to go on.
+	d.SetId(resource.UniqueId())
+
+	if err := d.Set("scheduler_algorithm", schedCfg.SchedulerConfig.SchedulerAlgorithm); err != nil {
+		return fmt.Errorf("failed to set scheduler_algorithm: %v", err)
+	}
+	premptMap := map[string]bool{
+		"batch_scheduler_enabled":   schedCfg.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled,
+		"service_scheduler_enabled": schedCfg.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled,
+		"system_scheduler_enabled":  schedCfg.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled,
+	}
+	if err := d.Set("preemption_config", premptMap); err != nil {
+		return fmt.Errorf("failed to set preemption_config: %v", err)
+	}
+	return nil
+}

--- a/nomad/data_source_scheduler_config_test.go
+++ b/nomad/data_source_scheduler_config_test.go
@@ -1,0 +1,55 @@
+package nomad
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceSchedulerConfig_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testFinalConfiguration,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNomadSchedulerConfigSpread,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"nomad_scheduler_config.config",
+						"scheduler_algorithm",
+						"spread",
+					),
+					resource.TestCheckResourceAttr(
+						"nomad_scheduler_config.config",
+						"preemption_config.batch_scheduler_enabled",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"nomad_scheduler_config.config",
+						"preemption_config.service_scheduler_enabled",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"nomad_scheduler_config.config",
+						"preemption_config.system_scheduler_enabled",
+						"true",
+					),
+				),
+			},
+		},
+	})
+}
+
+const testAccNomadDataSourceSchedulerConfigS = `
+resource "nomad_scheduler_config" "config" {
+	scheduler_algorithm = "spread"
+	preemption_config = {
+		system_scheduler_enabled = true
+		batch_scheduler_enabled = true
+		service_scheduler_enabled = true
+	}
+}
+
+data "nomad_scheduler_config" "config" {}
+`

--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -79,6 +79,7 @@ func Provider() terraform.ResourceProvider {
 			"nomad_plugins":          dataSourcePlugins(),
 			"nomad_scaling_policies": dataSourceScalingPolicies(),
 			"nomad_scaling_policy":   dataSourceScalingPolicy(),
+			"nomad_scheduler_config": dataSourceSchedulerConfig(),
 			"nomad_regions":          dataSourceRegions(),
 			"nomad_volumes":          dataSourceVolumes(),
 		},

--- a/website/docs/d/scheduler_config.html.md
+++ b/website/docs/d/scheduler_config.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # nomad_scheduler_config
 
-Retrieve the cluster's scheduler configuration.
+Retrieve the cluster's [scheduler configuration](https://www.nomadproject.io/api-docs/operator#sample-response-3).
 
 ## Example Usage
 
@@ -21,4 +21,4 @@ data "nomad_scheduler_config" "global" {}
 The following attributes are exported:
 
 * `scheduler_algorithm` `(string)` - Specifies whether scheduler binpacks or spreads allocations on available nodes.
-* `preemption_config` `(map[string]bool)` - TOptions to enable preemption for various schedulers.
+* `preemption_config` `(map[string]bool)` - Options to enable preemption for various schedulers.

--- a/website/docs/d/scheduler_config.html.md
+++ b/website/docs/d/scheduler_config.html.md
@@ -1,0 +1,24 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_scheduler_config"
+sidebar_current: "docs-nomad-datasource-scheduler-config"
+description: |-
+  Retrieve the cluster's scheduler configuration.
+---
+
+# nomad_scheduler_config
+
+Retrieve the cluster's scheduler configuration.
+
+## Example Usage
+
+```hcl
+data "nomad_scheduler_config" "global" {}
+```
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `scheduler_algorithm` `(string)` - Specifies whether scheduler binpacks or spreads allocations on available nodes.
+* `preemption_config` `(map[string]bool)` - TOptions to enable preemption for various schedulers.

--- a/website/nomad.erb
+++ b/website/nomad.erb
@@ -58,6 +58,9 @@
             <li<%= sidebar_current("docs-nomad-datasource-scaling-policy") %>>
               <a href="/docs/providers/nomad/d/scaling_policy.html">nomad_regions</a>
             </li>
+            <li<%= sidebar_current("docs-nomad-datasource-scheduler-config") %>>
+              <a href="/docs/providers/nomad/d/scheduler_config.html">nomad_scheduler_config</a>
+            </li>
             <li<%= sidebar_current("docs-nomad-datasource-volumes") %>>
               <a href="/docs/providers/nomad/d/volumes.html">nomad_volumes</a>
             </li>


### PR DESCRIPTION
There are no tests, because they unfortunately clash with the scheduler config resource, which updates the config values meaning the datasource tests have a race condition output with that. I'll think how to better approach this, but it highlights why this resource should be used carefully.

The dependancy update is unrelated to this change, but is needed as a result of 438a0b8 so is included.