### PR TITLE
Fix issue where volume register would not set namespace

### DIFF
--- a/nomad/resource_volume.go
+++ b/nomad/resource_volume.go
@@ -209,11 +209,6 @@ func resourceVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 	providerConfig := meta.(ProviderConfig)
 	client := providerConfig.client
 
-	ns := d.Get("namespace").(string)
-	if ns == "" {
-		ns = "default"
-	}
-
 	volume := &api.CSIVolume{
 		ID:             d.Get("volume_id").(string),
 		Name:           d.Get("name").(string),
@@ -245,7 +240,13 @@ func resourceVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Register the volume
 	log.Printf("[DEBUG] registering volume %q in namespace %q", volume.ID, volume.Namespace)
-	_, err := client.CSIVolumes().Register(volume, nil)
+	opts := &api.WriteOptions{
+		Namespace: d.Get("namespace").(string),
+	}
+	if opts.Namespace == "" {
+		opts.Namespace = "default"
+	}
+	_, err := client.CSIVolumes().Register(volume, opts)
 	if err != nil {
 		return fmt.Errorf("error registering volume: %s", err)
 	}


### PR DESCRIPTION
When registering a volume in a specific namespace, the provider would fail with the error:

```
Error: Provider produced inconsistent result after apply

When applying changes to nomad_volume.ebs, provider
"registry.terraform.io/hashicorp/nomad" produced an unexpected new value: Root
resource was present, but now absent.

This is a bug in the provider, which should be reported in the provider's own
issue tracker.
```

This happened because the registration action was not setting the namespace in the request, but the read (and delete) do, so the volume would 404 on read and the state would be inconsistent.