### PR TITLE
remove ENT warning

### DIFF
--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -10,9 +10,6 @@ description: |-
 
 Provisions a namespace within a Nomad cluster.
 
-~> **Enterprise Only!** This API endpoint and functionality only exists in
-Nomad Enterprise. This is not present in the open source version of Nomad.
-
 Nomad auto-generates a default namespace called `default`. This namespace
 cannot be removed, so destroying a `nomad_namespace` resource where
 `name = "default"` will cause the namespace to be reset to its default


### PR DESCRIPTION
remove Ent/OSS warning about namespace resource now that namespaces are available in OSS Nomad

resolves #176