### PR TITLE
provider: support TLS certs configured by strings.

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -44,14 +44,23 @@ The following arguments are supported:
   authority used to verify the remote agent's certificate. This can also be
   specified as the `NOMAD_CACERT` environment variable.
 
+- `ca_pem` `(string: "")` - PEM-encoded certificate authority used to verify
+  the remote agent's certificate.
+
 - `cert_file` `(string: "")` - A local file path to a PEM-encoded certificate
-  provided to the remote agent. If this is specified, `key_file` is also
-  required. This can also be specified as the `NOMAD_CLIENT_CERT` environment
-  variable.
+  provided to the remote agent. If this is specified, `key_file` or `key_pem`
+  is also required. This can also be specified as the `NOMAD_CLIENT_CERT`
+  environment variable.
+
+- `cert_pem` `(string: "")` - PEM-encoded certificate provided to the remote
+  agent. If this is specified, `key_file` or `key_pem` is also required.
 
 - `key_file` `(string: "")` - A local file path to a PEM-encoded private key.
-  This is required if `cert_file` is specified. This can also be specified via
-  the `NOMAD_CLIENT_KEY` environment variable.
+  This is required if `cert_file` or `cert_pem` is specified. This can also be
+  specified via the `NOMAD_CLIENT_KEY` environment variable.
+
+- `key_pem` `(string: "")` - PEM-encoded private key. This is required if
+  `cert_file` or `cert_pem` is specified.
 
 - `vault_token` `(string: "")` - A Vault token used when [submitting the job](https://www.nomadproject.io/docs/job-specification/job#vault_token).
   This can also be specified as the `VAULT_TOKEN` environment variable or using a


### PR DESCRIPTION
This change adds a number of new provider config params that allow users to configure TLS certificates via strings, alongside the pre-existing file location method.

The provider schema ConflictsWith param is used to notify users when a configuration attempts to use two keys which affect the same TLS config param. In order to successfully use this, the existing DefaultFunc default values have been moved from an empty string to nil. This is because Terraform treats an empty string var as being populated, and therefore raises a conflict error whenever a new param is set. I tested this change locally to ensure it didn't cause any compatibility issues, and didn't find any. It is reassures that the Consul provider went through the same change.

The provider doesn't have much testing around its configuration, so I will open an issue to improve this in the future. In the meantime when testing locally I used the [Nomad dev tls cluster](https://github.com/hashicorp/nomad/tree/master/dev/tls_cluster) along with the Terraform code below to test. The local plugin is located within `~/.terraform.d/plugins/hashicorp.com/hashicorp/nomad/0.1/darwin_amd64/`.

```hcl
provider "nomad" {
  address  = "https://127.0.0.1:4646"
  ca_pem   = file("~/go/src/github.com/hashicorp/nomad/dev/tls_cluster/certs/nomad-ca.pem")
  cert_pem = file("~/go/src/github.com/hashicorp/nomad/dev/tls_cluster/certs/server.pem")
  key_pem  = file("~/go/src/github.com/hashicorp/nomad/dev/tls_cluster/certs/server-key.pem")
}

resource "nomad_namespace" "test" {
  name = "test"
}

terraform {
  required_providers {
    nomad = {
      versions = ["0.1"]
      source   = "hashicorp.com/hashicorp/nomad"
    }
  }
}

```
closes #181 