### PR TITLE
ci: update hashistack deps

### DIFF
--- a/scripts/getconsul.sh
+++ b/scripts/getconsul.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONSUL_BINARY=https://releases.hashicorp.com/consul/1.8.5+ent/consul_1.8.5+ent_linux_amd64.zip
+CONSUL_BINARY=https://releases.hashicorp.com/consul/1.9.1+ent/consul_1.9.1+ent_linux_amd64.zip
 
 curl -L $CONSUL_BINARY > consul.zip
 sudo unzip -o consul.zip -d /usr/local/bin

--- a/scripts/getnomad.sh
+++ b/scripts/getnomad.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NOMAD_BINARY=https://releases.hashicorp.com/nomad/1.0.0-beta2+ent/nomad_1.0.0-beta2+ent_linux_amd64.zip
+NOMAD_BINARY=https://releases.hashicorp.com/nomad/1.0.2+ent/nomad_1.0.2+ent_linux_amd64.zip
 
 curl -L $NOMAD_BINARY > nomad.zip
 sudo unzip -o nomad.zip -d /usr/local/bin

--- a/scripts/getvault.sh
+++ b/scripts/getvault.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VAULT_BINARY=https://releases.hashicorp.com/vault/1.5.0+ent/vault_1.5.0+ent_linux_amd64.zip
+VAULT_BINARY=https://releases.hashicorp.com/vault/1.6.1+ent/vault_1.6.1+ent_linux_amd64.zip
 
 curl -L $VAULT_BINARY > vault.zip
 sudo unzip -o vault.zip -d /usr/local/bin


### PR DESCRIPTION
The HCL2 tests target Nomad 1.0.0+, so they weren't running on CI.