### PR TITLE
parsing to 1.0.4, testing changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/nomad v1.0.4
-	github.com/hashicorp/nomad/api v0.0.0-20210301154622-7832e0690701
+	github.com/hashicorp/nomad/api v0.0.0-20210223222946-149b150fb2d8
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/hashicorp/vault v0.10.4
 	github.com/mitchellh/mapstructure v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -451,6 +451,8 @@ github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69/go.mo
 github.com/hashicorp/nomad v1.0.4 h1:ZNP6kACeDctOL/vs3cTk0orYZPQa2ltC7jXxVYqLUbk=
 github.com/hashicorp/nomad v1.0.4/go.mod h1:JZx+1E1/ajixkE7tyJqCnmw6uN1fqpCKv8d9M42u7zg=
 github.com/hashicorp/nomad/api v0.0.0-20200529203653-c4416b26d3eb/go.mod h1:DCi2k47yuUDzf2qWAK8E1RVmWgz/lc0jZQeEnICTxmY=
+github.com/hashicorp/nomad/api v0.0.0-20210223222946-149b150fb2d8 h1:Yo0JMLg2d6BQhu4Y5mBKq6nQwkSD52jb6r58mY5TQ8I=
+github.com/hashicorp/nomad/api v0.0.0-20210223222946-149b150fb2d8/go.mod h1:vYHP9jMXk4/T2qNUbWlQ1OHCA1hHLil3nvqSmz8mtgc=
 github.com/hashicorp/nomad/api v0.0.0-20210301154622-7832e0690701 h1:v06dPD2EuzOp5hlJsG0oefUeQnKBxFkB/yrNCIRecAc=
 github.com/hashicorp/nomad/api v0.0.0-20210301154622-7832e0690701/go.mod h1:vYHP9jMXk4/T2qNUbWlQ1OHCA1hHLil3nvqSmz8mtgc=
 github.com/hashicorp/raft v1.1.1/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7k8sG/8=

--- a/nomad/provider_test.go
+++ b/nomad/provider_test.go
@@ -59,6 +59,26 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+func testEntFeatures(t *testing.T, requiredFeatures ...string) {
+	testCheckEnt(t)
+	client := testProvider.Meta().(ProviderConfig).client
+	resp, _, err := client.Operator().LicenseGet(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	licensedFeatures := map[string]bool{}
+	if resp != nil && resp.License != nil {
+		for _, f := range resp.License.Features {
+			licensedFeatures[f] = true
+		}
+	}
+	for _, f := range requiredFeatures {
+		if !licensedFeatures[f] {
+			t.Skip(fmt.Sprintf("license doesn't include required feature %q", f))
+		}
+	}
+}
+
 func testCheckEnt(t *testing.T) {
 	testCheckVersion(t, func(v version.Version) bool { return v.Metadata() == "ent" })
 }

--- a/nomad/resource_namespace_test.go
+++ b/nomad/resource_namespace_test.go
@@ -16,7 +16,7 @@ func TestResourceNamespace_import(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceNamespace_initialConfig(name),
@@ -37,7 +37,7 @@ func TestResourceNamespace_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceNamespace_initialConfig(name),
@@ -53,7 +53,7 @@ func TestResourceNamespace_refresh(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceNamespace_initialConfig(name),
@@ -75,7 +75,7 @@ func TestResourceNamespace_nameChange(t *testing.T) {
 	newName := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceNamespace_initialConfig(name),
@@ -95,7 +95,7 @@ func TestResourceNamespace_update(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceNamespace_initialConfig(name),
@@ -113,7 +113,7 @@ func TestResourceNamespace_deleteDefault(t *testing.T) {
 	name := api.DefaultNamespace
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceNamespace_initialConfig(name),

--- a/scripts/getnomad.sh
+++ b/scripts/getnomad.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NOMAD_BINARY=https://releases.hashicorp.com/nomad/1.0.2+ent/nomad_1.0.2+ent_linux_amd64.zip
+NOMAD_BINARY=https://releases.hashicorp.com/nomad/1.0.4+ent/nomad_1.0.4+ent_linux_amd64.zip
 
 curl -L $NOMAD_BINARY > nomad.zip
 sudo unzip -o nomad.zip -d /usr/local/bin


### PR DESCRIPTION
* set nomad parsing to 1.0.4 (was accidentally set to `HEAD` by previous PR)
* added tests for 1.0.4 features (terminating connect gateways)
* some general testing cleanup