### PR TITLE
fixes a typo in the job spec

### DIFF
--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -24,7 +24,7 @@ Registering a job from a jobspec file:
 
 ```hcl
 resource "nomad_job" "app" {
-  jobspec = file("${path.module}/jobpec.hcl")
+  jobspec = file("${path.module}/jobspec.hcl")
 }
 ```
 


### PR DESCRIPTION
Hello maintainers 👋🏼 

Just a small fix to the docs for the `nomad_job` resource.