### PR TITLE
Allow passing HCL2 variables to job

### DIFF
--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -715,7 +715,7 @@ func parseHCL2JobParserConfig(raw interface{}) (HCL2JobParserConfig, error) {
 	if vars, ok := hcl2Map["vars"].(map[string]interface{}); ok {
 		config.Vars = make(map[string]string)
 		for k, v := range vars {
-			config.Vars[k] = fmt.Sprintf("%s", v)
+			config.Vars[k] = v.(string)
 		}
 	}
 

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -92,6 +92,11 @@ func resourceJob() *schema.Resource {
 							Optional:    true,
 							Default:     false,
 						},
+						"vars": {
+							Description: "Additional variables to use when templating the job with HCL2",
+							Type:        schema.TypeMap,
+							Optional:    true,
+						},
 					},
 				},
 			},
@@ -282,6 +287,7 @@ type JSONJobParserConfig struct {
 type HCL2JobParserConfig struct {
 	Enabled bool
 	AllowFS bool
+	Vars    map[string]string
 }
 
 // ResourceFieldGetter are able to retrieve field values.
@@ -706,6 +712,12 @@ func parseHCL2JobParserConfig(raw interface{}) (HCL2JobParserConfig, error) {
 	if allowFS, ok := hcl2Map["allow_fs"].(bool); ok {
 		config.AllowFS = allowFS
 	}
+	if vars, ok := hcl2Map["vars"].(map[string]interface{}); ok {
+		config.Vars = make(map[string]string)
+		for k, v := range vars {
+			config.Vars[k] = fmt.Sprintf("%s", v)
+		}
+	}
 
 	return config, nil
 }
@@ -765,10 +777,16 @@ func parseJSONJobspec(raw string) (*api.Job, error) {
 }
 
 func parseHCL2Jobspec(raw string, config HCL2JobParserConfig) (*api.Job, error) {
+	argVars := []string{}
+	for k, v := range config.Vars {
+		argVars = append(argVars, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	return jobspec2.ParseWithConfig(&jobspec2.ParseConfig{
 		Path:    "",
 		Body:    []byte(raw),
 		AllowFS: config.AllowFS,
+		ArgVars: argVars,
 		Strict:  true,
 	})
 }

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -102,6 +102,45 @@ resource "nomad_job" "app" {
 }
 ```
 
+### Variables
+
+HCL2 variables can be passed from Terraform to the jobspec parser through the
+`vars` attribute inside the `hcl2` block. The variable must also be declared
+inside the jobspec as an [input variable](https://www.nomadproject.io/docs/job-specification/hcl2/variables#declaring-an-input-variable).
+
+Due to the way resource attributes are stored in the Terraform state, the
+values must be provided as strings.
+
+```hcl
+resource "nomad_job" "app" {
+  hcl2 {
+    enabled  = true
+    vars = {
+      "restart_attempts" = "5",
+      "datacenters"      = "[\"dc1\", \"dc2\"]",
+    }
+  }
+
+  jobspec = <<EOT
+variable "datacenters" {
+  type = list(string)
+}
+
+variable "restart_attempts" {
+  type = number
+}
+
+job "foo-hcl2" {
+  datacenters = var.datacenters
+
+  restart {
+    attempts = var.restart_attempts
+    ...
+  }
+  ...
+}
+```
+
 ### Filesystem functions
 
 Please note that [filesystem functions](https://www.nomadproject.io/docs/job-specification/hcl2/functions/file/abspath)


### PR DESCRIPTION
Add new attribute to the `hcl2` field in the `nomad_job` resource to allow passing extra HCL2 variable values.

Docs preview:
<img width="889" alt="image" src="https://user-images.githubusercontent.com/775380/113205587-76937380-923c-11eb-82c3-445c8acb9f04.png">


Closes #195 