### PR TITLE
Fix concurrent map access panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/nomad v1.0.4
-	github.com/hashicorp/nomad/api v0.0.0-20210223222946-149b150fb2d8
+	github.com/hashicorp/nomad/api v0.0.0-20210503143957-4ccada7924cf
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/hashicorp/vault v0.10.4
 	github.com/mitchellh/mapstructure v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -447,6 +447,8 @@ github.com/hashicorp/nomad v1.0.4/go.mod h1:JZx+1E1/ajixkE7tyJqCnmw6uN1fqpCKv8d9
 github.com/hashicorp/nomad/api v0.0.0-20200529203653-c4416b26d3eb/go.mod h1:DCi2k47yuUDzf2qWAK8E1RVmWgz/lc0jZQeEnICTxmY=
 github.com/hashicorp/nomad/api v0.0.0-20210223222946-149b150fb2d8 h1:Yo0JMLg2d6BQhu4Y5mBKq6nQwkSD52jb6r58mY5TQ8I=
 github.com/hashicorp/nomad/api v0.0.0-20210223222946-149b150fb2d8/go.mod h1:vYHP9jMXk4/T2qNUbWlQ1OHCA1hHLil3nvqSmz8mtgc=
+github.com/hashicorp/nomad/api v0.0.0-20210503143957-4ccada7924cf h1:l3e7dJU0mvrIHwYZ6RBf4F2bkrVXaBbsxTM9D07xQbw=
+github.com/hashicorp/nomad/api v0.0.0-20210503143957-4ccada7924cf/go.mod h1:vYHP9jMXk4/T2qNUbWlQ1OHCA1hHLil3nvqSmz8mtgc=
 github.com/hashicorp/raft v1.1.1/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7k8sG/8=
 github.com/hashicorp/raft v1.1.2/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7k8sG/8=
 github.com/hashicorp/raft v1.1.3-0.20200211192230-365023de17e6/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7k8sG/8=

--- a/nomad/provider_test.go
+++ b/nomad/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -132,11 +133,14 @@ func TestAccNomadProvider_Headers(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactoryInternal(&provider),
-		CheckDestroy:      nil,
+		CheckDestroy:      testAccCheckNomadProviderConfigWithHeadersCrashCheckDestroy(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNomadProviderConfigWithHeaders,
 				Check:  testAccCheckNomadProviderConfigWithHeaders(provider),
+			},
+			{
+				Config: testAccNomadProviderConfigWithHeadersCrash,
 			},
 		},
 	})
@@ -160,6 +164,30 @@ func testAccCheckNomadProviderConfigWithHeaders(provider *schema.Provider) resou
 	}
 }
 
+func testAccCheckNomadProviderConfigWithHeadersCrashCheckDestroy(provider *schema.Provider) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		providerConfig := provider.Meta().(ProviderConfig)
+		client := providerConfig.client
+		namespaces, _, err := client.Namespaces().List(nil)
+		if err != nil {
+			return err
+		}
+
+		count := 0
+		namespacePrefix := "headers-crash-test"
+		for _, ns := range namespaces {
+			if strings.HasPrefix(ns.Name, namespacePrefix) {
+				count++
+			}
+		}
+
+		if count != 0 {
+			return fmt.Errorf("%d namespaces still registered", count)
+		}
+		return nil
+	}
+}
+
 var testAccNomadProviderConfigWithHeaders = `
 provider "nomad" {
   headers {
@@ -178,6 +206,31 @@ provider "nomad" {
 
 // necessary to initialize the provider
 data "nomad_namespaces" "test" {}
+`
+
+var testAccNomadProviderConfigWithHeadersCrash = `
+provider "nomad" {
+  headers {
+    name = "Test-Header-1"
+	value = "a"
+  }
+  headers {
+    name = "Test-header-1"
+	value = "b"
+  }
+  headers {
+    name = "test-header-2"
+	value = "c"
+  }
+}
+
+// necessary to initialize the provider
+data "nomad_namespaces" "test" {}
+
+resource "nomad_namespace" "test" {
+  count = 100
+  name  = "headers-crash-test-${count.index}"
+}
 `
 
 func TestAccNomadProvider_ConsulToken(t *testing.T) {


### PR DESCRIPTION
#203 added support for additional headers for the provider, but also uncovered a [bug](https://github.com/hashicorp/nomad/pull/10302) in the Nomad `api` package that caused a panic whenever concurrent access to the header map happened.

The bug was fixed and this PR just pulls the latest released code.

A new test and a broken commit are provided to illustrate that this fixes the problem.

Closes #221 #222 #215