### PR TITLE
Update TravisCI base OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,41 @@
-dist: trusty
+dist: focal
 sudo: required
 services:
-- docker
+  - docker
 language: go
 go:
   - "1.14.x"
 
 before_install:
-- sudo apt-get update
-- sudo apt-get -y install httpie jq
+  - sudo apt-get update
+  - sudo apt-get -y install httpie jq
 
 install:
-# This script is used by the Travis build to install a cookie for
-# go.googlesource.com so rate limits are higher when using `go get` to fetch
-# packages that live there.
-# See: https://github.com/golang/go/issues/12933
-- bash scripts/gogetcookie.sh
-- bash scripts/getnomad.sh
-- bash scripts/getvault.sh
-- bash scripts/getconsul.sh
-
+  # This script is used by the Travis build to install a cookie for
+  # go.googlesource.com so rate limits are higher when using `go get` to fetch
+  # packages that live there.
+  # See: https://github.com/golang/go/issues/12933
+  - bash scripts/gogetcookie.sh
+  - bash scripts/getnomad.sh
+  - bash scripts/getvault.sh
+  - bash scripts/getconsul.sh
 
 before_script:
-- bash scripts/start-nomad.sh
+  - bash scripts/start-nomad.sh
 
 script:
-- make vet
-- NOMAD_TOKEN=$(cat /tmp/nomad-test.token) make testacc
+  - make vet
+  - NOMAD_TOKEN=$(cat /tmp/nomad-test.token) make testacc
 
 after_scripts:
-- bash scripts/stop-nomad.sh
+  - bash scripts/stop-nomad.sh
 
 branches:
   only:
-  - main
+    - main
 matrix:
   fast_finish: true
   allow_failures:
-  - go: tip
+    - go: tip
 env:
   - GO111MODULE=on


### PR DESCRIPTION
The `trusty` environment hit EOL, which was causing test to fail. Also updates YAML formatting.