### PR TITLE
Add timeout config to nomad_job resource

### DIFF
--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -26,6 +26,11 @@ func resourceJob() *schema.Resource {
 
 		CustomizeDiff: resourceJobCustomizeDiff,
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"jobspec": {
 				Description:      "Job specification. If you want to point to a file use the file() function.",

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -229,3 +229,13 @@ The following arguments are supported:
     format instead of the default HCL.
   - `allow_fs` `(boolean: false)` - Set this to `true` to be able to use
     [HCL2 filesystem functions](#filesystem-functions)
+
+### Timeouts
+
+`nomad_job` provides the following [`Timeouts`][tf_docs_timeouts] configuration
+options when [`detach`](#detach) is set to `false`:
+
+- `create` `(string: "5m")` - Timeout when registering a new job.
+- `update` `(string: "5m")` - Timeout when updating an existing job.
+
+[tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts


### PR DESCRIPTION
[Timeouts](https://www.terraform.io/docs/language/resources/syntax.html#operation-timeouts) were not being declared in the resource schema, so it was not possible to customize them.

Closes #210 