### PR TITLE
Add new CSI volume capabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ exclude (
 )
 
 require (
+	github.com/dustin/go-humanize v1.0.0
 	github.com/google/go-cmp v0.5.2
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,7 @@ github.com/docker/libnetwork v0.8.0-dev.2.0.20200612180813-9e99af28df21/go.mod h
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/go-bindata-assetfs v0.0.0-20160803192304-e1a2a7ec64b0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/elazarl/go-bindata-assetfs v1.0.1-0.20200509193318-234c15e7648f/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=

--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -144,6 +144,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"nomad_acl_policy":          resourceACLPolicy(),
 			"nomad_acl_token":           resourceACLToken(),
+			"nomad_external_volume":     resourceExternalVolume(),
 			"nomad_job":                 resourceJob(),
 			"nomad_namespace":           resourceNamespace(),
 			"nomad_quota_specification": resourceQuotaSpecification(),

--- a/nomad/resource_external_volume.go
+++ b/nomad/resource_external_volume.go
@@ -1,0 +1,329 @@
+package nomad
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"log"
+
+	"github.com/dustin/go-humanize"
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceExternalVolume() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceExternalVolumeCreate,
+		Update: resourceExternalVolumeCreate,
+		Delete: resourceExternalVolumeDelete,
+
+		// Once created, external volumes are automatically registered as a
+		// normal volume.
+		Read: resourceVolumeRead,
+
+		Schema: map[string]*schema.Schema{
+			"type": {
+				ForceNew:    true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The type of the volume. Currently, only 'csi' is supported.",
+				Default:     "csi",
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{"csi"}, false),
+				},
+			},
+
+			"namespace": {
+				ForceNew:    true,
+				Description: "The namespace in which to create the volume.",
+				Optional:    true,
+				Default:     "default",
+				Type:        schema.TypeString,
+			},
+
+			"volume_id": {
+				ForceNew:    true,
+				Description: "The unique ID of the volume, how jobs will refer to the volume.",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+
+			"name": {
+				Description: "The display name of the volume.",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+
+			"plugin_id": {
+				ForceNew:    true,
+				Description: "The ID of the CSI plugin that manages this volume.",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+
+			"snapshot_id": {
+				ForceNew:      true,
+				Description:   "The snapshot ID to restore when creating this volume. Storage provider must support snapshots. Conflicts with 'clone_id'.",
+				Optional:      true,
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"clone_id"},
+			},
+
+			"clone_id": {
+				ForceNew:      true,
+				Description:   "The volume ID to clone when creating this volume. Storage provider must support cloning. Conflicts with 'snapshot_id'.",
+				Optional:      true,
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"snapshot_id"},
+			},
+
+			"capacity_min": {
+				ForceNew:    true,
+				Description: "Defines how small the volume can be. The storage provider may return a volume that is larger than this value.",
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+
+			"capacity_max": {
+				ForceNew:    true,
+				Description: "Defines how large the volume can be. The storage provider may return a volume that is smaller than this value.",
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+
+			"capability": {
+				ForceNew:    true,
+				Description: "Capabilities intended to be used in a job. At least one capability must be provided.",
+				Required:    true,
+				Type:        schema.TypeSet,
+				MinItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"access_mode": {
+							Description: "Defines whether a volume should be available concurrently.",
+							Type:        schema.TypeString,
+							Required:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"single-node-reader-only",
+									"single-node-writer",
+									"multi-node-reader-only",
+									"multi-node-single-writer",
+									"multi-node-multi-writer",
+								}, false),
+							},
+						},
+						"attachment_mode": {
+							Description: "The storage API that will be used by the volume.",
+							Required:    true,
+							Type:        schema.TypeString,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"block-device",
+									"file-system",
+								}, false),
+							},
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-", m["access_mode"].(string)))
+					buf.WriteString(fmt.Sprintf("%s-", m["attachment_mode"].(string)))
+
+					i := int(crc32.ChecksumIEEE(buf.Bytes()))
+					if i >= 0 {
+						return i
+					}
+					if -i >= 0 {
+						return -i
+					}
+					// i == MinInt
+					return 0
+				},
+			},
+
+			"mount_options": {
+				Description: "Options for mounting 'block-device' volumes without a pre-formatted file system.",
+				Optional:    true,
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fs_type": {
+							Description: "The file system type.",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
+						"mount_flags": {
+							Description: "The flags passed to mount.",
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+					},
+				},
+			},
+
+			"secrets": {
+				Description: "An optional key-value map of strings used as credentials for publishing and unpublishing volumes.",
+				Optional:    true,
+				Type:        schema.TypeMap,
+				Sensitive:   true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"parameters": {
+				Description: "An optional key-value map of strings passed directly to the CSI plugin to configure the volume.",
+				Optional:    true,
+				Type:        schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"controller_required": {
+				Computed: true,
+				Type:     schema.TypeBool,
+			},
+
+			"controllers_expected": {
+				Computed: true,
+				Type:     schema.TypeInt,
+			},
+
+			"controllers_healthy": {
+				Computed: true,
+				Type:     schema.TypeInt,
+			},
+
+			"plugin_provider": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+
+			"plugin_provider_version": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+
+			"nodes_healthy": {
+				Computed: true,
+				Type:     schema.TypeInt,
+			},
+
+			"nodes_expected": {
+				Computed: true,
+				Type:     schema.TypeInt,
+			},
+
+			"schedulable": {
+				Computed: true,
+				Type:     schema.TypeBool,
+			},
+		},
+	}
+}
+
+func resourceExternalVolumeCreate(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(ProviderConfig)
+	client := providerConfig.client
+
+	// Parse capacities from human-friendly string to number.
+	capacityMin, err := humanize.ParseBytes(d.Get("capacity_min").(string))
+	if err != nil {
+		return fmt.Errorf("invalid value 'capacity_min': %v", err)
+	}
+
+	capacityMax, err := humanize.ParseBytes(d.Get("capacity_max").(string))
+	if err != nil {
+		return fmt.Errorf("invalid value 'capacity_max': %v", err)
+	}
+
+	// Parse capabilities set.
+	capabilities, err := parseVolumeCapabilities(d.Get("capability"))
+	if err != nil {
+		return fmt.Errorf("failed to unpack capabilities: %v", err)
+	}
+
+	volume := &api.CSIVolume{
+		ID:                    d.Get("volume_id").(string),
+		PluginID:              d.Get("plugin_id").(string),
+		Name:                  d.Get("name").(string),
+		SnapshotID:            d.Get("snapshot_id").(string),
+		CloneID:               d.Get("clone_id").(string),
+		RequestedCapacityMin:  int64(capacityMin),
+		RequestedCapacityMax:  int64(capacityMax),
+		RequestedCapabilities: capabilities,
+		Secrets:               toMapStringString(d.Get("secrets")),
+		Parameters:            toMapStringString(d.Get("parameters")),
+	}
+
+	// Unpack the mount_options if we have any and configure the volume struct.
+	mountOpts, ok := d.GetOk("mount_options")
+	if ok {
+		mountOptsList, ok := mountOpts.([]interface{})
+		if !ok || len(mountOptsList) != 1 {
+			return errors.New("failed to unpack mount_options configuration block")
+		}
+
+		mountOptsMap, ok := mountOptsList[0].(map[string]interface{})
+		if !ok {
+			return errors.New("failed to unpack mount_options configuration block")
+		}
+		volume.MountOptions = &api.CSIMountOptions{}
+
+		if val, ok := mountOptsMap["fs_type"].(string); ok {
+			volume.MountOptions.FSType = val
+		}
+		if val, ok := mountOptsMap["mount_flags"].([]string); ok {
+			volume.MountOptions.MountFlags = val
+		}
+	}
+
+	// Create the volume.
+	log.Printf("[DEBUG] creating volume %q in namespace %q", volume.ID, volume.Namespace)
+	opts := &api.WriteOptions{
+		Namespace: d.Get("namespace").(string),
+	}
+	if opts.Namespace == "" {
+		opts.Namespace = "default"
+	}
+	_, _, err = client.CSIVolumes().Create(volume, opts)
+	if err != nil {
+		return fmt.Errorf("error creating volume: %s", err)
+	}
+
+	log.Printf("[DEBUG] volume %q created in namespace %q", volume.ID, volume.Namespace)
+	d.SetId(volume.ID)
+
+	return resourceVolumeRead(d, meta) // populate other computed attributes
+}
+
+func resourceExternalVolumeDelete(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(ProviderConfig)
+	client := providerConfig.client
+
+	id := d.Id()
+	log.Printf("[DEBUG] deleting volume: %q", id)
+	opts := &api.WriteOptions{
+		Namespace: d.Get("namespace").(string),
+	}
+	if opts.Namespace == "" {
+		opts.Namespace = "default"
+	}
+	err := client.CSIVolumes().Delete(id, opts)
+	if err != nil {
+		return fmt.Errorf("error deleting volume: %s", err)
+	}
+
+	return nil
+}

--- a/website/nomad.erb
+++ b/website/nomad.erb
@@ -76,6 +76,10 @@
             <li<%= sidebar_current("docs-nomad-resource-acl-token") %>>
               <a href="/docs/providers/nomad/r/acl_token.html">nomad_acl_token</a>
             </li>
+            <li<%= sidebar_current("docs-nomad-resource-external-volume") %>>
+              <a href="/docs/providers/nomad/r/external_volume.html">nomad_external_volume</a>
+            </li>
+
             <li<%= sidebar_current("docs-nomad-resource-job") %>>
               <a href="/docs/providers/nomad/r/job.html">nomad_job</a>
             </li>
@@ -91,7 +95,7 @@
             <li<%= sidebar_current("docs-nomad-resource-scheduler-config") %>>
               <a href="/docs/providers/nomad/r/scheduler_config.html">nomad_scheduler_config</a>
             </li>
-            <li<%= sidebar_current("docs-nomad-resource-volume-policy") %>>
+            <li<%= sidebar_current("docs-nomad-resource-volume") %>>
               <a href="/docs/providers/nomad/r/volume.html">nomad_volume</a>
             </li>
           </ul>


### PR DESCRIPTION
Add a new resource, `nomad_external_volume` to use the new CSI capability in Nomad 1.1.0 to create and register external volumes through Nomad.

Also update the existing `nomad_volume` resource to [deprecate fields](https://www.nomadproject.io/docs/upgrade/upgrade-specific#csi-volumes), following the [official guidelines](https://www.terraform.io/docs/extend/best-practices/deprecations.html#renaming-a-required-attribute).

Closes #208 