### PR TITLE
fix nomad_plugin not waiting for expectedControllers reported by nomad

### DIFF
--- a/nomad/datasource_nomad_plugin.go
+++ b/nomad/datasource_nomad_plugin.go
@@ -123,7 +123,7 @@ func getPluginInfo(client *api.Client, d *schema.ResourceData) *resource.RetryEr
 		}
 		return resource.NonRetryableError(fmt.Errorf("error checking for plugin: %#v", err))
 	}
-	controllersExpected := len(plugin.Controllers)
+	controllersExpected := plugin.ControllersExpected
 	if waitForHealthy && controllersExpected != plugin.ControllersHealthy {
 		log.Printf("[DEBUG] plugin not yet healthy: %v/%v", controllersExpected, plugin.ControllersHealthy)
 		return resource.RetryableError(fmt.Errorf("plugin not yet healthy: %v/%v",

--- a/nomad/datasource_nomad_plugin.go
+++ b/nomad/datasource_nomad_plugin.go
@@ -135,7 +135,7 @@ func getPluginInfo(client *api.Client, d *schema.ResourceData) *resource.RetryEr
 	d.Set("plugin_provider", plugin.Provider)
 	d.Set("plugin_provider_version", plugin.Version)
 	d.Set("controller_required", plugin.ControllerRequired)
-	d.Set("controllers_expected", len(plugin.Controllers))
+	d.Set("controllers_expected", controllersExpected)
 	d.Set("controllers_healthy", plugin.ControllersHealthy)
 	d.Set("nodes_expected", len(plugin.Nodes))
 	d.Set("nodes_healthy", plugin.NodesHealthy)


### PR DESCRIPTION
I was having an issue using `nomad_external_volume` with the following snippet:
```hcl
resource "nomad_job" "plugin_digitalocean_monolith" {
  detach  = false
  jobspec = file("${path.module}/../../jobs/plugin-digitalocean-monolith.nomad")
}

data "nomad_plugin" "digitalocean" {
  depends_on   = [nomad_job.plugin_digitalocean_monolith]

  plugin_id        = "digitalocean"
  wait_for_registration = true
  wait_for_healthy = true
}

resource "nomad_external_volume" "cortex" {
  depends_on = [data.nomad_plugin.digitalocean]
  count        = 1
  type         = "csi"
  plugin_id    = data.nomad_plugin.digitalocean.plugin_id
  volume_id    = "cortex[${count.index}]"
  name         = "cortex-${count.index}"
  capacity_min = "1GiB"
  capacity_max = "10GiB"

  capability {
    access_mode     = "single-node-writer"
    attachment_mode = "file-system"
  }

  mount_options {
    fs_type = "ext4"
  }
}
```

with three nomad clients because `nomad_plugin` was immediately returning instead of waiting for the 3 controllers to be healthy. This caused the volume creation to fail with `500: plugin has no controller`. After doing some investigation, we noticed that `nomad_plugin` was reporting
```hcl
output "controller_required" {
  value = data.nomad_plugin.digitalocean.controller_required # == false
}

output "controllers_expected " {
  value = data.nomad_plugin.digitalocean.controllers_expected # == 0
}

output "controllers_healthy" {
  value = data.nomad_plugin.digitalocean.controllers_healthy # == 0
}
```

This led us to the line-edited below where it appears to be comparing the number of Controllers as reported by nomad vs the number of healthy controllers which will always be the same? Let me know if this assumption is wrong.

I tested this change locally and it is no longer giving a `500: plugin has no controller` error and seems to be waiting appropriately. 

Please let me know any comments/changes/concerns and I am happy to address them!