### PR TITLE
ci: fix nomad license env var check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,8 @@ jobs:
       - name: Run go vet
         run: make vet
       - name: Install vault, nomad, consul
+        env:
+          NOMAD_LICENSE: ${{ secrets.NOMAD_LICENSE }}
         run: |
           ./scripts/getnomad.sh
           ./scripts/getvault.sh
@@ -49,4 +51,3 @@ jobs:
         run: NOMAD_TOKEN=${{ env.NOMAD_TOKEN }} make testacc
       - name: Stop nomad
         run: ./scripts/stop-nomad.sh
-

--- a/scripts/getnomad.sh
+++ b/scripts/getnomad.sh
@@ -3,7 +3,7 @@
 set -e
 
 NOMAD_VERSION=1.1.0
-if [ -n "$NOMAD_LICENSE" || -n "$NOMAD_LICENSE_PATH" ]; then
+if [[ -n "$NOMAD_LICENSE" || -n "$NOMAD_LICENSE_PATH" ]]; then
     NOMAD_VERSION=${NOMAD_VERSION}+ent
 fi
 NOMAD_BINARY=https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip


### PR DESCRIPTION
The previous check would fail with this error:

```
./scripts/getnomad.sh: line 6: [: missing `]'
./scripts/getnomad.sh: line 6: -n: command not found
```