### PR TITLE
feat: add vault and consul token to job resource

### DIFF
--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -18,6 +18,10 @@ Nomad cluster often runs core system services that are ideally setup during
 infrastructure creation. This resource is ideal for the latter type of job, but
 can be used to manage any job within Nomad.
 
+~> **Warning:** this resource will store any sensitive values placed in
+  `consul_token` or `vault_token` in the Terraform's state file. Take care to
+  [protect your state file](/docs/state/sensitive-data.html).
+
 ## Example Usage
 
 Registering a job from a jobspec file:

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -233,6 +233,12 @@ The following arguments are supported:
   - `allow_fs` `(boolean: false)` - Set this to `true` to be able to use
     [HCL2 filesystem functions](#filesystem-functions)
 
+- `consul_token` `(string: <optional>)` - Consul token used when registering this job.
+  Will fallback to the value declared in Nomad provider configuration, if any.
+
+- `vault_token` `(string: <optional>)` - Vault token used when registering this job.
+  Will fallback to the value declared in Nomad provider configuration, if any.
+
 ### Timeouts
 
 `nomad_job` provides the following [`Timeouts`][tf_docs_timeouts] configuration


### PR DESCRIPTION
There is an implicit cyclic dependency between providers when you try to use dynamic (i.e., generated by another provider) `vault_token` and `consul_token` in your Nomad provider configuration. This change introduces the ability to provide `vault_token` and `consul_token` as part of the `nomad_job` resource, so that dynamic token values can be provided by `vault` and `consul` providers respectively without hitting the [provider dependency issue](https://github.com/hashicorp/terraform/issues/2430).

Let me know how I can ensure the registry docs are also up to date with this change, and let me know if anything else is needed! Thanks!