### PR TITLE
resource(volume): fix parsing mount_flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 * resource/scheduler_config: fixed an issue that caused the value of `memory_oversubscription_enabled` to never be set ([#259](https://github.com/hashicorp/terraform-provider-nomad/pull/259))
+* resource/volume: fixed a bug where volume mount flags were not set ([#269](https://github.com/hashicorp/terraform-provider-nomad/pull/269))
 
 ## 1.4.16 (November 24, 2021)
 

--- a/nomad/resource_volume.go
+++ b/nomad/resource_volume.go
@@ -347,8 +347,12 @@ func resourceVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 		if val, ok := mountOptsMap["fs_type"].(string); ok {
 			volume.MountOptions.FSType = val
 		}
-		if val, ok := mountOptsMap["mount_flags"].([]string); ok {
-			volume.MountOptions.MountFlags = val
+		rawMountFlags := mountOptsMap["mount_flags"].([]interface{})
+		volume.MountOptions.MountFlags = make([]string, len(rawMountFlags))
+		for index, value := range rawMountFlags {
+			if val, ok := value.(string); ok {
+				volume.MountOptions.MountFlags[index] = val
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes a bug where mount_flags were being silently dropped during resoruce creation.

I'm using Nomad v1.3.1 and terraform-provider-nomad v1.4.16.
I noticed that my `nomad_volume` `mount_options.mount_flags` weren't being set even though my `fs_type` **was** being set.
When creating the same volume directly with the `nomad` CLI mount_flags were being set so I knew it was a problem with the provider.

When the original error is not being ignored it causes a panic like so:

```
Stack trace from the terraform-provider-nomad_v1.4.16+dev plugin:

panic: interface conversion: interface {} is []interface {}, not []string

goroutine 55 [running]:
github.com/hashicorp/terraform-provider-nomad/nomad.resourceVolumeCreate(0xc00057f030, 0x1cbd860, 0xc00068c0c0, 0x24, 0x25a8540)
        /Users/pop/Projects/src/github.com/hashicorp/terraform-provider-nomad/nomad/resource_volume.go:353 +0xf77
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc0003ec000, 0xc000612c30, 0xc00077d400, 0x1cbd860, 0xc00068c0c0, 0x1c10501, 0xc00084f8d0, 0xc00081e3f0)
        /Users/pop/go/1.16.2/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.17.2/helper/schema/resource.go:326 +0x273
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).Apply(0xc000316b80, 0xc00084fa38, 0xc000612c30, 0xc00077d400, 0xc000473288, 0xc000033170, 0x1c12820)
        /Users/pop/go/1.16.2/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.17.2/helper/schema/provider.go:294 +0x99
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ApplyResourceChange(0xc000308890, 0x1f68090, 0xc0005d41b0, 0xc00057e1c0, 0xc000308890, 0xc0005d41b0, 0xc000860ba0)
        /Users/pop/go/1.16.2/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.17.2/internal/helper/plugin/grpc_provider.go:895 +0x8a5
github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0x1d1caa0, 0xc000308890, 0x1f68090, 0xc0005d41b0, 0xc0000ba6c0, 0x0, 0x1f68090, 0xc0005d41b0, 0xc0000f9800, 0x733)
        /Users/pop/go/1.16.2/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.17.2/internal/tfplugin5/tfplugin5.pb.go:3305 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000338000, 0x1f729b8, 0xc000626300, 0xc0000cc100, 0xc00032a510, 0x25670c0, 0x0, 0x0, 0x0)
        /Users/pop/go/1.16.2/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc000338000, 0x1f729b8, 0xc000626300, 0xc0000cc100, 0x0)
        /Users/pop/go/1.16.2/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc0000c6240, 0xc000338000, 0x1f729b8, 0xc000626300, 0xc0000cc100)
        /Users/pop/go/1.16.2/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /Users/pop/go/1.16.2/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd
```

I have tested this fix for me and it resolve the issue, but I didn't have time to write automated tests to catch future regressions.

Code feedback is more than welcome.