### PR TITLE
ci: stop Nomad before uploading logs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Run acceptance tests
         run: NOMAD_TOKEN=${{ env.NOMAD_TOKEN }} make testacc
       - name: Stop nomad
+        if: always()
         run: ./scripts/stop-nomad.sh
       - name: Make Nomad data dir and log file readable
         if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,3 +1,5 @@
+name: Test
+
 on:
   push:
 
@@ -29,6 +31,8 @@ jobs:
         run: ./scripts/start-nomad.sh
       - name: Run acceptance tests
         run: NOMAD_TOKEN=${{ env.NOMAD_TOKEN }} make testacc
+      - name: Stop nomad
+        run: ./scripts/stop-nomad.sh
       - name: Make Nomad data dir and log file readable
         if: always()
         run: |
@@ -47,5 +51,3 @@ jobs:
             !/tmp/nomad/data/**/alloc/logs/*.fifo
           if-no-files-found: warn
           retention-days: 3
-      - name: Stop nomad
-        run: ./scripts/stop-nomad.sh


### PR DESCRIPTION
I think the `actions/upload-artifact` may fail if the Nomad server is still writing to the log file. It's a big guess (I have no idea why [this](https://github.com/hashicorp/terraform-provider-nomad/runs/6814161240?check_suite_focus=true) failed), but it seems like the right order of operations regardless.