### PR TITLE
provider: add `ignore_env_vars` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.4.18 (Unreleased)
 
 IMPROVEMENTS:
-* provider: add `load_namespace_env_var` to allow loading the `NOMAD_NAMESPACE` environment variable ([#280](https://github.com/hashicorp/terraform-provider-nomad/pull/280))
+* provider: add `ignore_env_vars` configuration to allow specifying environment variables that should not be loaded by the provider. ([#281](https://github.com/hashicorp/terraform-provider-nomad/pull/281))
+* provider: ignore `NOMAD_NAMESPACE` and `NOMAD_REGION` when running in Terraform Cloud by default. ([#281](https://github.com/hashicorp/terraform-provider-nomad/pull/281))
 
 ## 1.4.17 (June 9, 2022)
 

--- a/nomad/provider_test.go
+++ b/nomad/provider_test.go
@@ -205,7 +205,9 @@ data "nomad_namespaces" "test" {}
 			{
 				Config: `
 provider "nomad" {
-  ignore_env_vars = ["NOMAD_NAMESPACE"]
+  ignore_env_vars = {
+    NOMAD_NAMESPACE: true,
+  }
 }
 
 // necessary to initialize the provider
@@ -243,6 +245,34 @@ data "nomad_namespaces" "test" {}
 					config := providerConfig.config
 
 					expect := ""
+					got := config.Namespace
+					if got != expect {
+						return fmt.Errorf("expected namespace to be %q, got %q", expect, got)
+					}
+					return nil
+				},
+			},
+			// Provider loads NOMAD_NAMESPACE even when running in TFC if user requests.
+			{
+				Config: `
+provider "nomad" {
+  ignore_env_vars = {
+    NOMAD_NAMESPACE: false,
+  }
+}
+
+// necessary to initialize the provider
+data "nomad_namespaces" "test" {}
+				`,
+				PreConfig: func() {
+					os.Setenv("NOMAD_NAMESPACE", "default")
+					os.Setenv("TFC_RUN_ID", "1")
+				},
+				Check: func(_ *terraform.State) error {
+					providerConfig := provider.Meta().(ProviderConfig)
+					config := providerConfig.config
+
+					expect := os.Getenv("NOMAD_NAMESPACE")
 					got := config.Namespace
 					if got != expect {
 						return fmt.Errorf("expected namespace to be %q, got %q", expect, got)
@@ -318,7 +348,9 @@ data "nomad_namespaces" "test" {}
 			{
 				Config: `
 provider "nomad" {
-  ignore_env_vars = ["NOMAD_REGION"]
+  ignore_env_vars = {
+    NOMAD_REGION: true,
+  }
 }
 
 // necessary to initialize the provider
@@ -356,6 +388,34 @@ data "nomad_namespaces" "test" {}
 					config := providerConfig.config
 
 					expect := ""
+					got := config.Region
+					if got != expect {
+						return fmt.Errorf("expected region to be %q, got %q", expect, got)
+					}
+					return nil
+				},
+			},
+			// Provider loads NOMAD_REGION even when running in TFC if user requests.
+			{
+				Config: `
+provider "nomad" {
+  ignore_env_vars = {
+    NOMAD_REGION: false,
+  }
+}
+
+// necessary to initialize the provider
+data "nomad_namespaces" "test" {}
+				`,
+				PreConfig: func() {
+					os.Setenv("NOMAD_REGION", "global")
+					os.Setenv("TFC_RUN_ID", "1")
+				},
+				Check: func(_ *terraform.State) error {
+					providerConfig := provider.Meta().(ProviderConfig)
+					config := providerConfig.config
+
+					expect := os.Getenv("NOMAD_REGION")
 					got := config.Region
 					if got != expect {
 						return fmt.Errorf("expected region to be %q, got %q", expect, got)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -40,13 +40,6 @@ The following arguments are supported:
 - `region` `(string: "")` - The Nomad region to target. This can also be
   specified as the `NOMAD_REGION` environment variable.
 
-- `load_namespace_env_var` `(bool: false)` - If true, the `NOMAD_NAMESPACE`
-  environment variable will be loaded into the provider configuration.
-
-    ~> **Warning:** This value should not be set (or set to `false`) when
-      running Terraform in environments where it runs within a Nomad
-      allocation, such as in Terraform Cloud.
-
 - `http_auth` `(string: "")` - HTTP Basic Authentication credentials to be used
   when communicating with Nomad, in the format of either `user` or `user:pass`.
   This can also be specified using the `NOMAD_HTTP_AUTH` environment variable.
@@ -90,6 +83,12 @@ The following arguments are supported:
 - `secret_id` `(string: "")` - The Secret ID of an ACL token to make requests with,
   for ACL-enabled clusters. This can also be specified via the `NOMAD_TOKEN`
   environment variable.
+
+- `ignore_env_vars` `([]string: [])` - A set of environment variables that are
+  ignored by the provider when configuring the Nomad API client. Supported
+  values are: `NOMAD_NAMESPACE` and `NOMAD_REGION`. When using the provider
+  with Terraform Cloud, the default value is set to `["NOMAD_NAMESPACE",
+  "NOMAD_REGION"]`.
 
 The `headers` configuration block accepts the following arguments:
 * `name` - (Required) The name of the header.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -84,11 +84,17 @@ The following arguments are supported:
   for ACL-enabled clusters. This can also be specified via the `NOMAD_TOKEN`
   environment variable.
 
-- `ignore_env_vars` `([]string: [])` - A set of environment variables that are
-  ignored by the provider when configuring the Nomad API client. Supported
-  values are: `NOMAD_NAMESPACE` and `NOMAD_REGION`. When using the provider
-  with Terraform Cloud, the default value is set to `["NOMAD_NAMESPACE",
-  "NOMAD_REGION"]`.
+- `ignore_env_vars` `(map[string]bool: {})` - A map of environment variables
+  that are ignored by the provider when configuring the Nomad API client.
+  Supported keys are: `NOMAD_NAMESPACE` and `NOMAD_REGION`. When using the
+  provider within Terraform Cloud, the default value is set to
+    ```
+    {
+      NOMAD_NAMESPACE: true,
+      NOMAD_REGION:    true,
+    }
+    ```.
+  Set these values to `false` if you need to load these environment variables.
 
 The `headers` configuration block accepts the following arguments:
 * `name` - (Required) The name of the header.


### PR DESCRIPTION
Add provider configuration option to allow users to ignore some
environment variables that would be otherwise loaded by default.

Read the `TFC_RUN_ID` environment variable to automatically ignore
`NOMAD_NAMESPACE` and `NOMAD_REGION`.

This re-implements #280 in a more re-usable way.

Closes #274