### PR TITLE
acl: add ACL Role resource and data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.4.19 (Unreleased)
 
 * **Target Nomad 1.4.1**: updated the nomad client to support Nomad API, jobspec, and fetures of version 1.4.1 ([#291](https://github.com/hashicorp/terraform-provider-nomad/pull/291))
+* **New Resource**: `nomad_acl_role` manages ACL roles in Nomad ([#284](https://github.com/hashicorp/terraform-provider-nomad/pull/284))
+* **New Data Source**: `nomad_acl_role` and `nomad_acl_roles` retrieves and lists ACL roles ([#284](https://github.com/hashicorp/terraform-provider-nomad/pull/284))
 
 IMPROVEMENTS:
 * resources/nomad_namespace: add support for `meta` and `capabilities` ([#287](https://github.com/hashicorp/terraform-provider-nomad/pull/287))

--- a/nomad/data_source_acl_role.go
+++ b/nomad/data_source_acl_role.go
@@ -1,0 +1,79 @@
+package nomad
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceACLRole() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceACLRoleRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ACL Role unique identifier.",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"name": {
+				Description: "Unique name of the ACL role.",
+				Computed:    true,
+				Type:        schema.TypeString,
+			},
+			"description": {
+				Description: "Description for the ACL role.",
+				Computed:    true,
+				Type:        schema.TypeString,
+			},
+			"policies": {
+				Description: "The list of policies applied to the role.",
+				Computed:    true,
+				Type:        schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The name of the ACL policy to link.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceACLRoleRead(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(ProviderConfig)
+	client := providerConfig.client
+
+	roleID := d.Get("id").(string)
+
+	log.Printf("[DEBUG] Reading ACL Role %q", roleID)
+	aclRole, _, err := client.ACLRoles().Get(roleID, nil)
+	if err != nil {
+
+		// As of Nomad 0.4.1, the API client returns an error for 404
+		// rather than a nil result, so we must check this way.
+		if strings.Contains(err.Error(), "404") {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading ACL Role %q: %s", roleID, err.Error())
+	}
+	log.Printf("[DEBUG] Read ACL Role %q", roleID)
+
+	policies := make([]map[string]interface{}, len(aclRole.Policies))
+	for i, policyLink := range aclRole.Policies {
+		policies[i] = map[string]interface{}{"name": policyLink.Name}
+	}
+
+	d.SetId(aclRole.ID)
+	d.Set("name", aclRole.Name)
+	d.Set("description", aclRole.Description)
+	d.Set("policies", policies)
+
+	return nil
+}

--- a/nomad/data_source_acl_role_test.go
+++ b/nomad/data_source_acl_role_test.go
@@ -13,7 +13,7 @@ func TestDataSourceACLRole(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.4.0-beta.1") },
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceACLRoleConfig,
@@ -54,8 +54,8 @@ resource "nomad_acl_role" "test" {
   name        = "acctest-acl-role"
   description = "A Terraform acctest ACL Role"
   depends_on  = [nomad_acl_policy.test]
-  
-  policies { 
+
+  policies {
     name = nomad_acl_policy.test.name
   }
 }

--- a/nomad/data_source_acl_role_test.go
+++ b/nomad/data_source_acl_role_test.go
@@ -1,0 +1,66 @@
+package nomad
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestDataSourceACLRole(t *testing.T) {
+	resourceName := "data.nomad_acl_role.test"
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceACLRoleConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testDataSourceACLRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "acctest-acl-role"),
+					resource.TestCheckResourceAttr(resourceName, "description", "A Terraform acctest ACL Role"),
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceACLRoleExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+		return nil
+	}
+}
+
+const testDataSourceACLRoleConfig = `
+resource "nomad_acl_policy" "test" {
+  name        = "acctest-acl-policy"
+  description = "A Terraform acctest ACL Policy"
+  rules_hcl   = <<EOT
+namespace "default" {
+  policy       = "read"
+  capabilities = ["submit-job"]
+}
+EOT
+}
+
+resource "nomad_acl_role" "test" {
+  name        = "acctest-acl-role"
+  description = "A Terraform acctest ACL Role"
+  depends_on  = [nomad_acl_policy.test]
+  
+  policies { 
+    name = nomad_acl_policy.test.name
+  }
+}
+
+data "nomad_acl_role" "test" {
+  id = nomad_acl_role.test.id
+}
+`

--- a/nomad/data_source_acl_role_test.go
+++ b/nomad/data_source_acl_role_test.go
@@ -55,7 +55,7 @@ resource "nomad_acl_role" "test" {
   description = "A Terraform acctest ACL Role"
   depends_on  = [nomad_acl_policy.test]
 
-  policies {
+  policy {
     name = nomad_acl_policy.test.name
   }
 }

--- a/nomad/data_source_acl_roles.go
+++ b/nomad/data_source_acl_roles.go
@@ -1,0 +1,90 @@
+package nomad
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceACLRoles() *schema.Resource {
+	return &schema.Resource{
+		Read: aclRolesDataSourceRead,
+
+		Schema: map[string]*schema.Schema{
+			"prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"acl_roles": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Description: "The ACL Role unique identifier.",
+							Computed:    true,
+							Type:        schema.TypeString,
+						},
+						"name": {
+							Description: "Unique name of the ACL role.",
+							Computed:    true,
+							Type:        schema.TypeString,
+						},
+						"description": {
+							Description: "Description for the ACL role.",
+							Computed:    true,
+							Type:        schema.TypeString,
+						},
+						"policies": {
+							Description: "The ACL policies applied to the role.",
+							Computed:    true,
+							Type:        schema.TypeSet,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "The name of the ACL policy to link.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func aclRolesDataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(ProviderConfig).client
+
+	qOpts := &api.QueryOptions{
+		Prefix: d.Get("prefix").(string),
+	}
+	aclRoles, _, err := client.ACLRoles().List(qOpts)
+	if err != nil {
+		return fmt.Errorf("failed to list ACL Roles: %v", err)
+	}
+
+	result := make([]map[string]interface{}, len(aclRoles))
+	for i, aclRole := range aclRoles {
+
+		policies := make([]map[string]interface{}, len(aclRole.Policies))
+		for i, policyLink := range aclRole.Policies {
+			policies[i] = map[string]interface{}{"name": policyLink.Name}
+		}
+
+		result[i] = map[string]interface{}{
+			"id":          aclRole.ID,
+			"name":        aclRole.Name,
+			"description": aclRole.Description,
+			"policies":    policies,
+		}
+	}
+
+	d.SetId("nomad-roles")
+	return d.Set("acl_roles", result)
+}

--- a/nomad/data_source_acl_roles_test.go
+++ b/nomad/data_source_acl_roles_test.go
@@ -11,7 +11,7 @@ func TestDataSourceACLRoles(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.4.0-beta.1") },
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceACLRolesConfig,
@@ -44,8 +44,8 @@ resource "nomad_acl_role" "test" {
   name        = "acctest-acl-role"
   description = "A Terraform acctest ACL Role"
   depends_on  = [nomad_acl_policy.test]
-  
-  policies { 
+
+  policies {
     name = nomad_acl_policy.test.name
   }
 }

--- a/nomad/data_source_acl_roles_test.go
+++ b/nomad/data_source_acl_roles_test.go
@@ -1,0 +1,56 @@
+package nomad
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestDataSourceACLRoles(t *testing.T) {
+	resourceName := "data.nomad_acl_roles.test"
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceACLRolesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "prefix"),
+					resource.TestCheckResourceAttr(resourceName, "acl_roles.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "acl_roles.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "acl_roles.0.name", "acctest-acl-role"),
+					resource.TestCheckResourceAttr(resourceName, "acl_roles.0.description", "A Terraform acctest ACL Role"),
+					resource.TestCheckResourceAttr(resourceName, "acl_roles.0.policies.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceACLRolesConfig = `
+resource "nomad_acl_policy" "test" {
+  name        = "acctest-acl-policy"
+  description = "A Terraform acctest ACL Policy"
+  rules_hcl   = <<EOT
+namespace "default" {
+  policy       = "read"
+  capabilities = ["submit-job"]
+}
+EOT
+}
+
+resource "nomad_acl_role" "test" {
+  name        = "acctest-acl-role"
+  description = "A Terraform acctest ACL Role"
+  depends_on  = [nomad_acl_policy.test]
+  
+  policies { 
+    name = nomad_acl_policy.test.name
+  }
+}
+
+data "nomad_acl_roles" "test" {
+  prefix = split("-", nomad_acl_role.test.id)[0]
+}
+`

--- a/nomad/data_source_acl_roles_test.go
+++ b/nomad/data_source_acl_roles_test.go
@@ -45,7 +45,7 @@ resource "nomad_acl_role" "test" {
   description = "A Terraform acctest ACL Role"
   depends_on  = [nomad_acl_policy.test]
 
-  policies {
+  policy {
     name = nomad_acl_policy.test.name
   }
 }

--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -133,6 +133,8 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"nomad_acl_policies":     dataSourceAclPolicies(),
 			"nomad_acl_policy":       dataSourceAclPolicy(),
+			"nomad_acl_role":         dataSourceACLRole(),
+			"nomad_acl_roles":        dataSourceACLRoles(),
 			"nomad_acl_token":        dataSourceACLToken(),
 			"nomad_acl_tokens":       dataSourceACLTokens(),
 			"nomad_datacenters":      dataSourceDatacenters(),
@@ -152,6 +154,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"nomad_acl_policy":          resourceACLPolicy(),
+			"nomad_acl_role":            resourceACLRole(),
 			"nomad_acl_token":           resourceACLToken(),
 			"nomad_external_volume":     resourceExternalVolume(),
 			"nomad_job":                 resourceJob(),

--- a/nomad/resource_acl_role.go
+++ b/nomad/resource_acl_role.go
@@ -1,0 +1,173 @@
+package nomad
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceACLRole() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceACLRoleCreate,
+		Update: resourceACLRoleUpdate,
+		Delete: resourceACLRoleDelete,
+		Read:   resourceACLRoleRead,
+		Exists: resourceACLRoleExists,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Description: "Unique name for this ACL role.",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"description": {
+				Description: "Description for this ACL role.",
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			"policies": {
+				Description: "The policies that should be applied to the role.",
+				Required:    true,
+				Type:        schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The name of the ACL policy to link.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceACLRoleCreate(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(ProviderConfig)
+	client := providerConfig.client
+
+	role := generateNomadACLRole(d)
+
+	// Create our ACL role.
+	log.Printf("[DEBUG] Creating ACL role")
+	aclRoleCreateResp, _, err := client.ACLRoles().Create(role, nil)
+	if err != nil {
+		return fmt.Errorf("error creating ACL role: %s", err.Error())
+	}
+
+	d.SetId(aclRoleCreateResp.ID)
+	log.Printf("[DEBUG] Created ACL role %q", aclRoleCreateResp.ID)
+
+	return resourceACLRoleRead(d, meta)
+}
+
+func resourceACLRoleUpdate(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(ProviderConfig)
+	client := providerConfig.client
+
+	role := generateNomadACLRole(d)
+
+	// Perform the in-place update of the ACL role.
+	log.Printf("[DEBUG] Updating ACL Role %q", role.ID)
+	_, _, err := client.ACLRoles().Update(role, nil)
+	if err != nil {
+		return fmt.Errorf("error updating ACL Role %q: %s", role.ID, err.Error())
+	}
+	log.Printf("[DEBUG] Updated ACL Role %q", role.ID)
+
+	return resourceACLRoleRead(d, meta)
+}
+
+func resourceACLRoleDelete(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(ProviderConfig)
+	client := providerConfig.client
+
+	roleID := d.Id()
+
+	// Delete the ACL role.
+	log.Printf("[DEBUG] Deleting ACL Role %q", roleID)
+	_, err := client.ACLRoles().Delete(roleID, nil)
+	if err != nil {
+		return fmt.Errorf("error deleting ACL Role %q: %s", roleID, err.Error())
+	}
+	log.Printf("[DEBUG] Deleted ACL Role %q", roleID)
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceACLRoleRead(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(ProviderConfig)
+	client := providerConfig.client
+	roleID := d.Id()
+
+	// If the role has not been created, the ID will be an empty string which
+	// means we can skip attempting to perform the lookup.
+	if roleID == "" {
+		return nil
+	}
+
+	log.Printf("[DEBUG] Reading ACL Role %q", roleID)
+	role, _, err := client.ACLRoles().Get(roleID, nil)
+	if err != nil {
+		return fmt.Errorf("error reading ACL Role %q: %s", roleID, err.Error())
+	}
+	log.Printf("[DEBUG] Read ACL Role %q", roleID)
+
+	policies := make([]map[string]interface{}, len(role.Policies))
+	for i, policyLink := range role.Policies {
+		policies[i] = map[string]interface{}{"name": policyLink.Name}
+	}
+
+	d.Set("name", role.Name)
+	d.Set("description", role.Description)
+	d.Set("policies", policies)
+
+	return nil
+}
+
+func resourceACLRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	providerConfig := meta.(ProviderConfig)
+	client := providerConfig.client
+
+	roleID := d.Id()
+	log.Printf("[DEBUG] Checking if ACL Role %q exists", roleID)
+	_, _, err := client.ACLRoles().Get(roleID, nil)
+	if err != nil {
+		// As of Nomad 0.4.1, the API client returns an error for 404
+		// rather than a nil result, so we must check this way.
+		if strings.Contains(err.Error(), "404") {
+			return false, nil
+		}
+
+		return true, fmt.Errorf("error checking for ACL Role %q: %#v", roleID, err)
+	}
+
+	return true, nil
+}
+
+func generateNomadACLRole(d *schema.ResourceData) *api.ACLRole {
+
+	policies := make([]*api.ACLRolePolicyLink, 0)
+
+	for _, raw := range d.Get("policies").(*schema.Set).List() {
+		s := raw.(map[string]interface{})
+		policies = append(policies, &api.ACLRolePolicyLink{Name: s["name"].(string)})
+	}
+
+	return &api.ACLRole{
+		ID:          d.Id(),
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Policies:    policies,
+	}
+}

--- a/nomad/resource_acl_role.go
+++ b/nomad/resource_acl_role.go
@@ -32,8 +32,8 @@ func resourceACLRole() *schema.Resource {
 				Optional:    true,
 				Type:        schema.TypeString,
 			},
-			"policies": {
-				Description: "The policies that should be applied to the role.",
+			"policy": {
+				Description: "The policies that should be applied to the role. It may be used multiple times.",
 				Required:    true,
 				Type:        schema.TypeSet,
 				Elem: &schema.Resource{
@@ -130,7 +130,7 @@ func resourceACLRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", role.Name)
 	d.Set("description", role.Description)
-	d.Set("policies", policies)
+	d.Set("policy", policies)
 
 	return nil
 }
@@ -159,7 +159,7 @@ func generateNomadACLRole(d *schema.ResourceData) *api.ACLRole {
 
 	policies := make([]*api.ACLRolePolicyLink, 0)
 
-	for _, raw := range d.Get("policies").(*schema.Set).List() {
+	for _, raw := range d.Get("policy").(*schema.Set).List() {
 		s := raw.(map[string]interface{})
 		policies = append(policies, &api.ACLRolePolicyLink{Name: s["name"].(string)})
 	}

--- a/nomad/resource_acl_role_test.go
+++ b/nomad/resource_acl_role_test.go
@@ -18,7 +18,7 @@ func TestResourceACLRole(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.4.0-beta.1") },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceACLRoleConfig(testResourceName, testResourceName),
@@ -50,8 +50,8 @@ resource "nomad_acl_role" "test" {
   name        = %q
   description = "A Terraform acctest ACL role"
   depends_on  = [nomad_acl_policy.test]
-  
-  policies { 
+
+  policies {
     name = nomad_acl_policy.test.name
   }
 } `, policyName, roleName)

--- a/nomad/resource_acl_role_test.go
+++ b/nomad/resource_acl_role_test.go
@@ -1,0 +1,136 @@
+package nomad
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestResourceACLRole(t *testing.T) {
+
+	testResourceName := acctest.RandomWithPrefix("tf-nomad-test")
+	testACLRoleNameUpdated := testResourceName + "-updated"
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLRoleConfig(testResourceName, testResourceName),
+				Check:  testResourceACLRoleCheck(testResourceName),
+			},
+			{
+				Config: testResourceACLRoleConfig(testResourceName, testACLRoleNameUpdated),
+				Check:  testResourceACLRoleCheck(testACLRoleNameUpdated),
+			},
+		},
+		CheckDestroy: resourceACLRoleCheckDestroy,
+	})
+}
+
+func testResourceACLRoleConfig(policyName, roleName string) string {
+	return fmt.Sprintf(`
+resource "nomad_acl_policy" "test" {
+  name        = %q
+  description = "A Terraform acctest ACL policy"
+  rules_hcl   = <<EOT
+namespace "default" {
+  policy       = "read"
+  capabilities = ["submit-job"]
+}
+EOT
+}
+
+resource "nomad_acl_role" "test" {
+  name        = %q
+  description = "A Terraform acctest ACL role"
+  depends_on  = [nomad_acl_policy.test]
+  
+  policies { 
+    name = nomad_acl_policy.test.name
+  }
+} `, policyName, roleName)
+}
+
+func testResourceACLRoleCheck(roleName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		resourceState := s.Modules[0].Resources["nomad_acl_role.test"]
+		if resourceState == nil {
+			return errors.New("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return errors.New("resource has no primary instance")
+		}
+
+		if instanceState.ID == "" {
+			return fmt.Errorf("expected ID to be set, got %q", instanceState.ID)
+		}
+
+		if len(instanceState.Attributes["id"]) < 1 {
+			return fmt.Errorf("expected id to be set, got %q", instanceState.Attributes["id"])
+		}
+
+		if instanceState.Attributes["name"] != roleName {
+			return fmt.Errorf("expected name to be %q, is %q in state", roleName, instanceState.Attributes["name"])
+		}
+
+		// because policies is a set, it's a pain to try and check the values here
+		if instanceState.Attributes["policies.#"] != "1" {
+			return fmt.Errorf(`expected policies.# to be "1", is %q in state`,
+				instanceState.Attributes["policies.#"])
+		}
+
+		client := testProvider.Meta().(ProviderConfig).client
+		role, _, err := client.ACLRoles().Get(instanceState.ID, nil)
+		if err != nil {
+			return fmt.Errorf("error reading back ACL role %q: %s", instanceState.ID, err)
+		}
+
+		if role.Name != roleName {
+			return fmt.Errorf("expected name to be %q, is %q in API", roleName, role.Name)
+		}
+		if len(role.Policies) != 1 {
+			return fmt.Errorf("expected %d policies, got %v from the API", 1, role.Policies)
+		}
+
+		return nil
+	}
+}
+
+func resourceACLRoleCheckDestroy(s *terraform.State) error {
+
+	client := testProvider.Meta().(ProviderConfig).client
+
+	for _, s := range s.Modules[0].Resources {
+
+		if s.Primary == nil {
+			continue
+		}
+
+		switch s.Type {
+		case "nomad_acl_role":
+			role, _, err := client.ACLRoles().Get(s.Primary.ID, nil)
+			if err != nil && strings.Contains(err.Error(), "404") || role == nil {
+				continue
+			}
+			return fmt.Errorf("ACL Role %q has not been deleted.", role.ID)
+		case "nomad_acl_policy":
+			policy, _, err := client.ACLPolicies().Info(s.Primary.ID, nil)
+			if err != nil && strings.Contains(err.Error(), "404") || policy == nil {
+				continue
+			}
+			return fmt.Errorf("ACL Policy %q has not been deleted.", policy.Name)
+		default:
+			continue
+		}
+	}
+	return nil
+}

--- a/website/docs/d/acl_role.html.markdown
+++ b/website/docs/d/acl_role.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_acl_role"
+sidebar_current: "docs-nomad-datasource-acl-role"
+description: |-
+Get information on an ACL Role.
+---
+
+# nomad_acl_role
+
+Get information on an ACL Role.
+
+## Example Usage
+
+```hcl
+data "nomad_acl_role" "example" {
+  id = "aa534e09-6a07-0a45-2295-a7f77063d429"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id`: `(string)` The unique identifier of the ACL Role.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` `(string)` - The ACL Role unique identifier.
+* `name` `(string)` - Unique name of the ACL role.
+* `description` `(string)` - The description of the ACL Role.
+* `policies` `(set)` - The policies applied to the role.

--- a/website/docs/d/acl_roles.html.markdown
+++ b/website/docs/d/acl_roles.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_acl_roles"
+sidebar_current: "docs-nomad-datasource-acl_roles"
+description: |-
+Retrieve a list of ACL Roles.
+---
+
+# nomad_acl_roles
+
+Retrieve a list of ACL Roles.
+
+## Example Usage
+
+```hcl
+data "nomad_acl_roles" "example" {
+  prefix = "a242"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `prefix`: `(string)` An optional string to filter ACL Roles based on ID 
+  prefix. If not provided, all policies are returned.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `roles`: `list of maps` a list of ACL Roles.
+    * `id` `(string)` - The ACL Role unique identifier.
+    * `name` `(string)` - Unique name of the ACL role.
+    * `description` `(string)` - The description of the ACL Role.
+    * `policies` `(set)` - The policies applied to the role.

--- a/website/docs/d/acl_roles.html.markdown
+++ b/website/docs/d/acl_roles.html.markdown
@@ -22,7 +22,7 @@ data "nomad_acl_roles" "example" {
 
 The following arguments are supported:
 
-* `prefix`: `(string)` An optional string to filter ACL Roles based on ID 
+* `prefix`: `(string)` An optional string to filter ACL Roles based on ID
   prefix. If not provided, all policies are returned.
 
 ## Attribute Reference

--- a/website/docs/r/acl_role.html.markdown
+++ b/website/docs/r/acl_role.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_acl_role"
+sidebar_current: "docs-nomad-resource-acl-role"
+description: |-
+Manages an ACL Role in Nomad.
+---
+
+# nomad_acl_role
+
+Manages an ACL Role in Nomad.
+
+## Example Usage
+
+Creating an ALC Role linked to an ACL policy also created by Terraform:
+
+```hcl
+resource "nomad_acl_policy" "my_nomad_acl_policy" {
+  name        = "my-nomad-acl-policy"
+  rules_hcl   = <<EOT
+namespace "default" {
+  policy       = "read"
+  capabilities = ["submit-job"]
+}
+EOT
+}
+
+resource "nomad_acl_role" "my_nomad_acl_role" {
+  name        = "my-nomad-acl-role"
+  description = "An ACL Role for cluster developers"
+  
+  policies {
+    name = nomad_acl_policy.my_nomad_acl_policy.name
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` `(string: <required>)` - A human-friendly name for this ACL Role.
+
+- `description` `(string: "")` - A description of the ACL Role.
+
+- `policies` `(set: <required>)` - A set of policy names to associate with this
+  ACL Role.

--- a/website/docs/r/acl_role.html.markdown
+++ b/website/docs/r/acl_role.html.markdown
@@ -28,8 +28,8 @@ EOT
 resource "nomad_acl_role" "my_nomad_acl_role" {
   name        = "my-nomad-acl-role"
   description = "An ACL Role for cluster developers"
-  
-  policies {
+
+  policy {
     name = nomad_acl_policy.my_nomad_acl_policy.name
   }
 }
@@ -43,5 +43,5 @@ The following arguments are supported:
 
 - `description` `(string: "")` - A description of the ACL Role.
 
-- `policies` `(set: <required>)` - A set of policy names to associate with this
-  ACL Role.
+- `policy` `(set: <required>)` - A set of policy names to associate with this
+  ACL Role. It may be used multiple times.


### PR DESCRIPTION
This change adds a new `nomad_acl_role` resource along with `nomad_acl_role` and `nomad_acl_roles` datasources.

In order to raise the change, the Nomad dependency has been updated to latest. This should be fixed to a release tag once 1.4.0 is released.

The tests do not currently run because the CI process requires a released version of Nomad :D. We can either merge this as is, or hold off until 1.4.0; but raising the PR now for early review.