### PR TITLE
Add ns meta and capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 1.4.18 (Unreleased)
+## 1.4.19 (Unreleased)
+
+IMPROVEMENTS:
+* resources/nomad_namespace: add support for `meta` and `capabilities` ([#287](https://github.com/hashicorp/terraform-provider-nomad/pull/287))
+* data source/nomad_namespace: add support for `meta` and `capabilities` ([#287](https://github.com/hashicorp/terraform-provider-nomad/pull/287))
+
+## 1.4.18 (August 31, 2022)
 
 * **Target Nomad 1.3.4**: updated the nomad client to support Nomad API and jobspec version 1.3.4 ([#282](https://github.com/hashicorp/terraform-provider-nomad/pull/282))
 

--- a/nomad/data_source_namespace.go
+++ b/nomad/data_source_namespace.go
@@ -23,6 +23,18 @@ func dataSourceNamespace() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"meta": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"capabilities": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     resourceNamespaceCapabilities(),
+			},
 		},
 	}
 }
@@ -41,6 +53,12 @@ func namespaceDataSourceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err = d.Set("quota", ns.Quota); err != nil {
 		return fmt.Errorf("Failed to set 'quota': %v", err)
+	}
+	if err = d.Set("meta", ns.Meta); err != nil {
+		return fmt.Errorf("Failed to set 'meta': %v", err)
+	}
+	if err = d.Set("capabilities", flattenNamespaceCapabilities(ns.Capabilities)); err != nil {
+		return fmt.Errorf("Failed to set 'capabilities': %v", err)
 	}
 
 	d.SetId(client.Address() + "/namespace/" + name)

--- a/nomad/data_source_namespace_test.go
+++ b/nomad/data_source_namespace_test.go
@@ -1,21 +1,25 @@
 package nomad
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestDataSourceNamespace(t *testing.T) {
 	resourceName := "data.nomad_namespace.test"
+	name := acctest.RandomWithPrefix("tf-nomad-test")
 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testAccPreCheck(t); testCheckEnt(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceNamespaceConfig,
+				Config: testDataSourceDefaultNamespaceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "default"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Default shared namespace"),
@@ -26,11 +30,30 @@ func TestDataSourceNamespace(t *testing.T) {
 				Config:      testDataSourceNamespaceConfig_doesNotExists,
 				ExpectError: regexp.MustCompile("Namespace not found"),
 			},
+			{
+				Config: testDataSourceNamespace_basicConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					func() resource.TestCheckFunc {
+						return func(s *terraform.State) error {
+							t.Log(s)
+							return nil
+						}
+					}(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "A Terraform acctest namespace"),
+					resource.TestCheckResourceAttr(resourceName, "quota", ""),
+					resource.TestCheckResourceAttr(resourceName, "meta.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "capabilities.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "capabilities.795649181.disabled_task_drivers.0", "raw_exec"),
+					resource.TestCheckResourceAttr(resourceName, "capabilities.795649181.enabled_task_drivers.0", "docker"),
+					resource.TestCheckResourceAttr(resourceName, "capabilities.795649181.enabled_task_drivers.1", "exec"),
+				),
+			},
 		},
 	})
 }
 
-const testDataSourceNamespaceConfig = `
+const testDataSourceDefaultNamespaceConfig = `
 data "nomad_namespace" "test" {
 	name = "default"
 }
@@ -41,3 +64,25 @@ data "nomad_namespace" "test" {
 	name = "does-not-exists"
 }
 `
+
+func testDataSourceNamespace_basicConfig(name string) string {
+	return fmt.Sprintf(`
+resource "nomad_namespace" "test" {
+  name = "%s"
+  description = "A Terraform acctest namespace"
+
+  meta = {
+    key = "value",
+  }
+
+  capabilities {
+    enabled_task_drivers  = ["docker", "exec"]
+    disabled_task_drivers = ["raw_exec"]
+  }
+}
+
+data "nomad_namespace" "test" {
+  name = nomad_namespace.test.name
+}
+`, name)
+}

--- a/nomad/data_source_namespace_test.go
+++ b/nomad/data_source_namespace_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestDataSourceNamespace(t *testing.T) {
@@ -33,12 +32,6 @@ func TestDataSourceNamespace(t *testing.T) {
 			{
 				Config: testDataSourceNamespace_basicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					func() resource.TestCheckFunc {
-						return func(s *terraform.State) error {
-							t.Log(s)
-							return nil
-						}
-					}(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "description", "A Terraform acctest namespace"),
 					resource.TestCheckResourceAttr(resourceName, "quota", ""),

--- a/nomad/resource_namespace.go
+++ b/nomad/resource_namespace.go
@@ -56,6 +56,7 @@ func resourceNamespace() *schema.Resource {
 				Optional:    true,
 				Type:        schema.TypeSet,
 				Elem:        resourceNamespaceCapabilities(),
+				MaxItems:    1,
 			},
 		},
 	}

--- a/website/docs/d/namespace.html.markdown
+++ b/website/docs/d/namespace.html.markdown
@@ -26,5 +26,9 @@ data "nomad_namespace" "namespaces" {
 
 The following attributes are exported:
 
-- `description` `(string)` - The description of the namespace.
-- `quota` `(string)` - The quota associated with the namespace.
+* `description` `(string)` - The description of the namespace.
+* `quota` `(string)` - The quota associated with the namespace.
+* `meta` `(map[string]string)` -  Arbitrary KV metadata associated with the namespace.
+* `capabilities` `(block)` - Capabilities of the namespace
+  * `enabled_task_drivers` `([]string)` - Task drivers enabled for the namespace.
+  * `disabled_task_drivers` `([]string)` - Task drivers disabled for the namespace.

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -24,6 +24,10 @@ resource "nomad_namespace" "dev" {
   name        = "dev"
   description = "Shared development environment."
   quota       = "dev"
+  meta        = {
+    owner = "John Doe"
+    foo   = "bar"
+  }
 }
 ```
 
@@ -58,3 +62,15 @@ The following arguments are supported:
 - `name` `(string: <required>)` - A unique name for the namespace.
 - `description` `(string: "")` - A description of the namespace.
 - `quota` `(string: "")` - A resource quota to attach to the namespace.
+- `meta` `(map[string]string: <optional>)` -  Specifies arbitrary KV metadata to associate with the namespace.
+- `capabilities` `(block: <optional>)` - A block of capabilities for the namespace. Can't 
+  be repeated. See below for the structure of this block.
+
+
+### `capabilities` blocks
+
+The `capabilities` block describes the capabilities of the namespace. It supports
+the following arguments:
+
+- `enabled_task_drivers` `([]string: <optional>)` - Task drivers enabled for the namespace.
+- `disabled_task_drivers` `([]string: <optional>)` - Task drivers disabled for the namespace.


### PR DESCRIPTION
This PR adds the new blocks `meta` and `capabilities` for the namespace resource and data.