### PR TITLE
feat: add option to skip tls verfication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## 1.4.20 (Unreleased)
+
 * **Target Nomad 1.5.2**: updated the nomad client to support Nomad API, jobspec, and features of version 1.5.2 ([#305](https://github.com/hashicorp/terraform-provider-nomad/pull/305))
 * **New Resource**: `nomad_acl_auth_method` manages ACL auth methods in Nomad ([#305](https://github.com/hashicorp/terraform-provider-nomad/pull/305))
 * **New Resource**: `nomad_acl_binding_rule` manages ACL binding rules in Nomad ([#305](https://github.com/hashicorp/terraform-provider-nomad/pull/305))
+
+IMPROVEMENTS:
+* provider: add `skip_verify` configuration to skip TLS verification ([#319](https://github.com/hashicorp/terraform-provider-nomad/pull/319))
 
 ## 1.4.19 (October 20, 2022)
 

--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -129,6 +129,12 @@ func Provider() *schema.Provider {
 				Description: "A set of environment variables that are ignored by the provider when configuring the Nomad API client.",
 				Elem:        &schema.Schema{Type: schema.TypeBool},
 			},
+			"skip_verify": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NOMAD_SKIP_VERIFY", false),
+				Description: "Skip TLS verification on client side.",
+			},
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -238,6 +244,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	conf.TLSConfig.CACertPEM = []byte(d.Get("ca_pem").(string))
 	conf.TLSConfig.ClientCertPEM = []byte(d.Get("cert_pem").(string))
 	conf.TLSConfig.ClientKeyPEM = []byte(d.Get("key_pem").(string))
+	conf.TLSConfig.Insecure = d.Get("skip_verify").(bool)
 
 	if _, ok := os.LookupEnv("TF_ACC"); ok {
 		// Revert the Nomad API client to non-pooled to avoid EOF errors when

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -66,6 +66,9 @@ The following arguments are supported:
 - `key_pem` `(string: "")` - PEM-encoded private key. This is required if
   `cert_file` or `cert_pem` is specified.
 
+- `skip_verify` `(boolean: false)` - Set this to true if you want to skip TLS verification on the client side. 
+  This can also be specified via the `NOMAD_SKIP_VERIFY` environment variable.
+
 - `headers` - (Optional) A configuration block, described below, that provides headers
   to be sent along with all requests to Nomad.  This block can be specified
   multiple times.


### PR DESCRIPTION
Add `skip_verify` as an optional parameter to the schema to be able to skip TLS verification.