### PR TITLE
Fix make localtestacc

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,10 +16,13 @@ test: fmtcheck
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -count=1
 
-localtestacc: fmtcheck
-	-export NOMAD_TOKEN=$(shell scripts/start-nomad.sh); \
-	export TF_ACC=1; \
-	go test $(TEST) -v $(TESTARGS) -timeout 120m -count=1
+localtestacc-start-nomad:
+	scripts/start-nomad.sh
+
+localtestacc: fmtcheck localtestacc-start-nomad
+	-env NOMAD_TOKEN=$(shell cat /tmp/nomad-test.token) \
+		TF_ACC=1 \
+		go test $(TEST) -v $(TESTARGS) -timeout 120m -count=1
 	scripts/stop-nomad.sh
 
 vet:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ localtestacc-start-nomad:
 	scripts/start-nomad.sh
 
 localtestacc: fmtcheck localtestacc-start-nomad
-	-env NOMAD_TOKEN=$(shell cat /tmp/nomad-test.token) \
+	-env NOMAD_TOKEN=00000000-0000-0000-0000-000000000000 \
 		TF_ACC=1 \
 		go test $(TEST) -v $(TESTARGS) -timeout 120m -count=1
 	scripts/stop-nomad.sh
@@ -60,4 +60,3 @@ endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
 .PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website
-

--- a/scripts/getconsul.sh
+++ b/scripts/getconsul.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-CONSUL_VERSION=1.9.5+ent
+CONSUL_VERSION=1.15.3+ent
 CONSUL_BINARY=https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
 
 curl -L $CONSUL_BINARY > consul.zip

--- a/scripts/getnomad.sh
+++ b/scripts/getnomad.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-NOMAD_VERSION=1.4.1
+NOMAD_VERSION=1.5.6
 if [[ -n "$NOMAD_LICENSE" || -n "$NOMAD_LICENSE_PATH" ]]; then
     NOMAD_VERSION=${NOMAD_VERSION}+ent
 fi

--- a/scripts/getvault.sh
+++ b/scripts/getvault.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-VAULT_VERSION=1.7.2+ent
+VAULT_VERSION=1.13.2+ent
 VAULT_BINARY=https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
 
 curl -L $VAULT_BINARY > vault.zip

--- a/scripts/start-nomad.sh
+++ b/scripts/start-nomad.sh
@@ -2,7 +2,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-
 set -e
 
 export VAULT_TEST_TOKEN=terraform-provider-nomad-token
@@ -33,15 +32,14 @@ plugin "docker" {
 }
 EOF
 
-    sudo -Eb nomad agent -dev -acl-enabled \
+    sudo -Eb bash -c 'nomad agent -dev -acl-enabled \
       -data-dir=/tmp/nomad/data \
       -config=/tmp/nomad-config.hcl \
       -vault-address=$VAULT_ADDR \
       -vault-token=$VAULT_TEST_TOKEN \
       -vault-enabled \
-      -vault-allow-unauthenticated=false
-    NOMAD_PID=$!
-    echo $NOMAD_PID > /tmp/nomad-test.pid
+      -vault-allow-unauthenticated=false & \
+      echo $! > /tmp/nomad-test.pid'
 
     # Give some time for the process to initialize
     sleep 10
@@ -50,27 +48,37 @@ EOF
     while [ $retries -ge 0 ]; do
       nomad acl bootstrap -json | jq -r '.SecretID' > /tmp/nomad-test.token && break
       sleep 5
-      retries=$(( $retries - 1 ))
+      retries=$(( retries - 1 ))
     done
-    export NOMAD_TOKEN=$(cat /tmp/nomad-test.token)
+    NOMAD_TOKEN=$(cat /tmp/nomad-test.token)
+    export NOMAD_TOKEN
     if [ -z "$NOMAD_TOKEN" ]; then
-      echo "Failed to bootstrap Nomad ACL"
+      echo "Failed to bootstrap Nomad ACL" 1>&2
       exit 1
     fi
-    echo "NOMAD_TOKEN=$(echo $NOMAD_TOKEN)" >> $GITHUB_ENV
+
+    if [ -z "$GITHUB_ENV" ]; then
+      echo "$NOMAD_TOKEN"
+    else
+      echo "NOMAD_TOKEN=$NOMAD_TOKEN" >> "$GITHUB_ENV"
+    fi
 
     # Run hostpath CSI plugin and wait for it to be healthy.
-    nomad job run https://raw.githubusercontent.com/hashicorp/nomad/v1.3.1/demo/csi/hostpath/plugin.nomad
-    echo "Waiting for hostpath CSI plugin to become healthy"
+    nomad job run https://raw.githubusercontent.com/hashicorp/nomad/v1.3.1/demo/csi/hostpath/plugin.nomad 1>&2
+    echo "Waiting for hostpath CSI plugin to become healthy" 1>&2
     retries=30
     while [ $retries -ge 0 ]; do
         nomad plugin status hostpath \
-            | grep "Nodes Healthy        = 1" && break
+            | grep -q "Nodes Healthy        = 1" && break
         sleep 2
-        retries=$(( $retries - 1 ))
+        retries=$(( retries - 1 ))
     done
-    nomad plugin status hostpath
+    nomad plugin status hostpath 1>&2
 elif [ -e /tmp/nomad-test.token ]; then
-  NOMAD_TOKEN=$(cat /tmp/nomad-test.token)
-  echo "NOMAD_TOKEN=$(echo $NOMAD_TOKEN)" >> $GITHUB_ENV
+    NOMAD_TOKEN=$(cat /tmp/nomad-test.token)
+    if [ -z "$GITHUB_ENV" ]; then
+      echo "$NOMAD_TOKEN"
+    else
+      echo "NOMAD_TOKEN=$NOMAD_TOKEN" >> "$GITHUB_ENV"
+    fi
 fi

--- a/scripts/stop-nomad.sh
+++ b/scripts/stop-nomad.sh
@@ -2,11 +2,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+if [ -e /tmp/consul-test.pid ]; then
+    echo "Stopping consul"
+    kill "$(cat /tmp/consul-test.pid)" && rm -f /tmp/consul-test.pid
+fi
+if [ -e /tmp/vault-test.pid ]; then
+    echo "Stopping vault"
+    kill "$(cat /tmp/vault-test.pid)" && rm -f /tmp/vault-test.pid
+fi
+if [ -e /tmp/nomad-test.pid ]; then
+    echo "Stopping nomad"
+    sudo kill "$(cat /tmp/nomad-test.pid)" && sudo rm -f /tmp/nomad-test.pid
+fi
 
-[ -e /tmp/consul-test.pid ] && echo "Stopping consul" && kill $(cat /tmp/consul-test.pid)
-rm -f /tmp/consul-test.pid
-[ -e /tmp/vault-test.pid ] && echo "Stopping vault" && kill $(cat /tmp/vault-test.pid)
-rm -f /tmp/vault-test.pid
-[ -e /tmp/nomad-test.pid ] && echo "Stopping nomad" && kill $(cat /tmp/nomad-test.pid)
-rm -f /tmp/nomad-test.pid
 rm -f /tmp/nomad-test.token


### PR DESCRIPTION
There are a few layered bugs that this fixes.

1.  When trying to capture the output of `scripts/start-nomad.sh`, the `shell` function never exits. I believe it's waiting on all processes spawned to exist, but we don't kill them until after the test. So the test execution was hanging. This was resolved by avoiding capture and instead reading the token from a file.
2. Apparently the shell function substitution doesn't happen sequentially within the target. When running the script and trying reading the variable using `$(shell cat /tmp/nomad-test.token)` right after, an error that `/tmp/nomad-test.token` doesn't exist is echoed before the script is even run. In order to ensure the script is run before trying to read the token, this is moved to a different target.
3. Output from the running nomad was being echoed to the screen despite the process being in the background. This is resolved by redirecting the output.
4. Running `stop-nomad.sh` stopped consul and vault, but not nomad. This is because `$! was actually capturing the pid of consul a second time because nomad was backgrounded by `sudo` and not the current shell. This was resolved by having sudo execute a bash shell and have that spawned shell capture the pid instead.
5. Capturing output as `env NOMAD_TOKEN=$(./scripts/star-nomad.sh)` wouldn't have worked anyway because it was actually echoing `NOMAD_TOKEN=<THETOKEN>` as well as a bunch of stdout from nomad commands. This was resolved by conditionally echoing the token alone and extraneous stdout to stderr.
6. Finally, the pid files were being deleted even if the kill commands were not successful. This could have been resolved by adding `set -e`, but I refactored it a bit more to kill whatever it could but allow retrying or further investigation for processes it couldn't kill.