### PR TITLE
making bind_name optional when bind_type is management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 * data source/nomad_volume: fix panic when reading volume ([#323](https://github.com/hashicorp/terraform-provider-nomad/pull/323))
+* resources/nomad_acl_binding_rule: fix a bug where `bind_name` was required even when `bind_type` was `management`. ([#330](https://github.com/hashicorp/terraform-provider-nomad/pull/330))
 
 ## 1.4.20 (April 20, 2023)
 

--- a/nomad/resource_acl_binding_rule.go
+++ b/nomad/resource_acl_binding_rule.go
@@ -187,12 +187,15 @@ func validateNomadACLBindingRule(d *schema.ResourceData) error {
 	bindName := d.Get("bind_name").(string)
 	bindType := d.Get("bind_type").(string)
 
-	if bindType != api.ACLBindingRuleBindTypeManagement && bindName == "" {
-		return fmt.Errorf("error bind_name must be defined if bind_type is not '%q'", api.ACLBindingRuleBindTypeManagement)
-	}
-
-	if bindType == api.ACLBindingRuleBindTypeManagement && bindName != "" {
-		return fmt.Errorf("error bind_name must not be defined if bind_type is '%q'", api.ACLBindingRuleBindTypeManagement)
+	switch bindType {
+	case api.ACLBindingRuleBindTypeManagement:
+		if bindName != "" {
+			return fmt.Errorf("error bind_name must not be defined if bind_type is '%q'", api.ACLBindingRuleBindTypeManagement)
+		}
+	default:
+		if bindName == "" {
+			return fmt.Errorf("error bind_name must be defined if bind_type is '%q'", bindType)
+		}
 	}
 
 	return nil

--- a/website/docs/r/acl_binding_rule.html.markdown
+++ b/website/docs/r/acl_binding_rule.html.markdown
@@ -66,7 +66,9 @@ The following arguments are supported:
 - `bind_type` `(string: <required>)` - Adjusts how this binding rule is applied
   at login time. Valid values are `role`, `policy`, and `management`.
 
-- `bind_name` `(string: "")` - Target of the binding.
+- `bind_name` `(string: <optional>)` - Target of the binding. If `bind_type` is
+  `role` or `policy` then `bind_name` is required. If `bind_type` is
+  `management` than `bind_name` must not be defined.
 
 - `config`: `(block: <required>)` - Configuration specific to the auth method
   provider.


### PR DESCRIPTION
When creating a ACL binding rule, the bind name must not be defined but only when the bind_type is set to management.

https://developer.hashicorp.com/nomad/docs/commands/acl/binding-rule/create

Fixes #324