### PR TITLE
ci: fix tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,8 @@ jobs:
         run: ./scripts/start-nomad.sh
       - name: Run acceptance tests
         run: NOMAD_TOKEN=${{ env.NOMAD_TOKEN }} make testacc
+        env:
+          NOMAD_TOKEN: 00000000-0000-0000-0000-000000000000
       - name: Stop nomad
         if: always()
         run: ./scripts/stop-nomad.sh

--- a/scripts/getconsul.sh
+++ b/scripts/getconsul.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-CONSUL_VERSION=1.15.3+ent
+CONSUL_VERSION=1.15.3
 CONSUL_BINARY=https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
 
 curl -L $CONSUL_BINARY > consul.zip

--- a/scripts/getnomad.sh
+++ b/scripts/getnomad.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-NOMAD_VERSION=1.5.6
+NOMAD_VERSION=1.5.0
 if [[ -n "$NOMAD_LICENSE" || -n "$NOMAD_LICENSE_PATH" ]]; then
     NOMAD_VERSION=${NOMAD_VERSION}+ent
 fi

--- a/scripts/getvault.sh
+++ b/scripts/getvault.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-VAULT_VERSION=1.13.2+ent
+VAULT_VERSION=1.13.2
 VAULT_BINARY=https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
 
 curl -L $VAULT_BINARY > vault.zip


### PR DESCRIPTION
I accidentally removed this line to set `NOMAD_TOKEN` to the runner environment in #326
https://github.com/hashicorp/terraform-provider-nomad/pull/326/commits/98e16b2ec4fca80a8f233e5f916dab980d725f8d#diff-a2adceb1476caa3f0076774cc3848b480976990a98d90b9fec9254a8a61a8bceL63

I also bumped Consul and Vault in that PR, but these newer enterprise versions require a license, but it turns out we don't actually need the ENT version of those tools in our tests, just Nomad.