### PR TITLE
resource_volume : set topology_request on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ BUG FIXES:
 * data source/namespace: use type list to represent capabilities so its values can be indexed with Terraform SDKv2 ([#339](https://github.com/hashicorp/terraform-provider-nomad/issues/339))
 * data source/nomad_volume: fix panic when reading volume ([#323](https://github.com/hashicorp/terraform-provider-nomad/pull/323))
 * resources/nomad_acl_binding_rule: fix a bug where `bind_name` was required even when `bind_type` was `management`. ([#330](https://github.com/hashicorp/terraform-provider-nomad/pull/330))
+* resource/nomad_volume and resource/nomad_external_volume: fix a bug where `topology_request` was not persisted to state. ([#342](https://github.com/hashicorp/terraform-provider-nomad/pull/342)
 
 ## 1.4.20 (April 20, 2023)
 

--- a/nomad/resource_csi_volume.go
+++ b/nomad/resource_csi_volume.go
@@ -183,6 +183,7 @@ func resourceCSIVolume() *schema.Resource {
 			},
 
 			"topology_request": {
+				ForceNew:    true,
 				Description: "Specify locations (region, zone, rack, etc.) where the provisioned volume is accessible from.",
 				Optional:    true,
 				Type:        schema.TypeList,
@@ -190,6 +191,7 @@ func resourceCSIVolume() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"required": {
+							ForceNew:    true,
 							Description: "Required topologies indicate that the volume must be created in a location accessible from all the listed topologies.",
 							Optional:    true,
 							Type:        schema.TypeList,
@@ -197,12 +199,14 @@ func resourceCSIVolume() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"topology": {
+										ForceNew:    true,
 										Description: "Defines the location for the volume.",
 										Required:    true,
 										Type:        schema.TypeList,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"segments": {
+													ForceNew:    true,
 													Description: "Define the attributes for the topology request.",
 													Required:    true,
 													Type:        schema.TypeMap,
@@ -217,6 +221,7 @@ func resourceCSIVolume() *schema.Resource {
 							},
 						},
 						"preferred": {
+							ForceNew:    true,
 							Description: "Preferred topologies indicate that the volume should be created in a location accessible from some of the listed topologies.",
 							Optional:    true,
 							Type:        schema.TypeList,
@@ -224,12 +229,14 @@ func resourceCSIVolume() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"topology": {
+										ForceNew:    true,
 										Description: "Defines the location for the volume.",
 										Required:    true,
 										Type:        schema.TypeList,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"segments": {
+													ForceNew:    true,
 													Description: "Define the attributes for the topology request.",
 													Required:    true,
 													Type:        schema.TypeMap,

--- a/nomad/resource_external_volume.go
+++ b/nomad/resource_external_volume.go
@@ -196,6 +196,7 @@ func resourceExternalVolume() *schema.Resource {
 			},
 
 			"topology_request": {
+				ForceNew:    true,
 				Description: "Specify locations (region, zone, rack, etc.) where the provisioned volume is accessible from.",
 				Optional:    true,
 				Type:        schema.TypeList,
@@ -203,6 +204,7 @@ func resourceExternalVolume() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"required": {
+							ForceNew:    true,
 							Description: "Required topologies indicate that the volume must be created in a location accessible from all the listed topologies.",
 							Optional:    true,
 							Type:        schema.TypeList,
@@ -210,12 +212,14 @@ func resourceExternalVolume() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"topology": {
+										ForceNew:    true,
 										Description: "Defines the location for the volume.",
 										Required:    true,
 										Type:        schema.TypeList,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"segments": {
+													ForceNew:    true,
 													Description: "Define the attributes for the topology request.",
 													Required:    true,
 													Type:        schema.TypeMap,
@@ -230,6 +234,7 @@ func resourceExternalVolume() *schema.Resource {
 							},
 						},
 						"preferred": {
+							ForceNew:    true,
 							Description: "Preferred topologies indicate that the volume should be created in a location accessible from some of the listed topologies.",
 							Optional:    true,
 							Type:        schema.TypeList,
@@ -237,12 +242,14 @@ func resourceExternalVolume() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"topology": {
+										ForceNew:    true,
 										Description: "Defines the location for the volume.",
 										Required:    true,
 										Type:        schema.TypeList,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"segments": {
+													ForceNew:    true,
 													Description: "Define the attributes for the topology request.",
 													Required:    true,
 													Type:        schema.TypeMap,

--- a/nomad/resource_volume.go
+++ b/nomad/resource_volume.go
@@ -188,6 +188,7 @@ func resourceVolume() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"required": {
+							ForceNew:    true,
 							Description: "Required topologies indicate that the volume must be created in a location accessible from all the listed topologies.",
 							Optional:    true,
 							Type:        schema.TypeList,
@@ -195,12 +196,14 @@ func resourceVolume() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"topology": {
+										ForceNew:    true,
 										Description: "Defines the location for the volume.",
 										Required:    true,
 										Type:        schema.TypeList,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"segments": {
+													ForceNew:    true,
 													Description: "Define attributes for the topology request.",
 													Required:    true,
 													Type:        schema.TypeMap,
@@ -662,6 +665,9 @@ func flattenVolumeTopologyRequests(topologyReqs *api.CSITopologyRequest) []inter
 
 	if topologyReqs.Required != nil {
 		topologyMap["Required"] = flattenVolumeTopologies(topologyReqs.Required)
+	}
+	if topologyReqs.Preferred != nil {
+		topologyMap["Preferred"] = flattenVolumeTopologies(topologyReqs.Preferred)
 	}
 
 	return topologyRequestList

--- a/nomad/resource_volume.go
+++ b/nomad/resource_volume.go
@@ -180,6 +180,7 @@ func resourceVolume() *schema.Resource {
 			},
 
 			"topology_request": {
+				ForceNew:    true,
 				Description: "Specify locations (region, zone, rack, etc.) where the provisioned volume is accessible from.",
 				Optional:    true,
 				Type:        schema.TypeList,
@@ -508,6 +509,7 @@ func resourceVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("nodes_expected", volume.NodesExpected)
 	d.Set("schedulable", volume.Schedulable)
 	d.Set("topologies", flattenVolumeTopologies(volume.Topologies))
+	d.Set("topology_request", flattenVolumeTopologyRequests(volume.RequestedTopologies))
 	// The Nomad API redacts `mount_options` and `secrets`, so we don't update them
 	// with the response payload; they will remain as is.
 
@@ -645,6 +647,24 @@ func flattenVolumeTopologies(topologies []*api.CSITopology) []interface{} {
 	}
 
 	return topologiesList
+}
+
+// flattenVolumeTopologyRequests turns a list of Nomad API CSITopologyRequest structs into
+// the flat representation used by Terraform.
+func flattenVolumeTopologyRequests(topologyReqs *api.CSITopologyRequest) []interface{} {
+	if topologyReqs == nil {
+		return nil
+	}
+
+	topologyRequestList := make([]interface{}, 1)
+	topologyMap := make(map[string]interface{}, 1)
+	topologyRequestList[0] = topologyMap
+
+	if topologyReqs.Required != nil {
+		topologyMap["Required"] = flattenVolumeTopologies(topologyReqs.Required)
+	}
+
+	return topologyRequestList
 }
 
 // resourceVolumeStateUpgradeV0 migrates a nomad_volume resource schema from v0 to v1.


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-nomad/issues/338

The MR covers only `required` topology_request as that's what's implemented in the schema for this resource. Should it be extended to account also for `preferred`? According the the [Volume Specification](https://developer.hashicorp.com/nomad/docs/other-specifications/volume) they are both supported.