### PR TITLE
resource/nomad_job: switch to HCL2 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 BACKWARDS INCOMPATIBILITIES:
 * provider: Terraform Plugin SDK upgraded to v2.10.1. **Terraform versions prior to 0.12 are no longer supported.** ([#339](https://github.com/hashicorp/terraform-provider-nomad/issues/339))
+* resource/nomad_job: Switch to HCL2 parsing by default. Jobs that require HCL1 parsing must set `hcl1 = true`. ([#343](https://github.com/hashicorp/terraform-provider-nomad/pull/343))
 
 IMPROVEMENTS:
 * provider: add `skip_verify` configuration to skip TLS verification ([#319](https://github.com/hashicorp/terraform-provider-nomad/pull/319))

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -91,7 +91,7 @@ func resourceJob() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Description: "If true, the `jobspec` will be parsed as HCL2 instead of HCL.",
-							Deprecated:  "Starting with version 2.0.0 of the Nomad provider, jobs are parsed using HCL2 by default so this field is no longer used and may be safely removed from your configuration files. Set 'hcl1 = true' if you must use HCL1 job parsing.",
+							Deprecated:  "Starting with version 2.0.0 of the Nomad provider, jobs are parsed using HCL2 by default, so this field is no longer used and may be safely removed from your configuration files. Set 'hcl1 = true' if you must use HCL1 job parsing.",
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     false,

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -91,6 +91,7 @@ func resourceJob() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Description: "If true, the `jobspec` will be parsed as HCL2 instead of HCL.",
+							Deprecated:  "Starting with version 2.0.0 of the Nomad provider, jobs are parsed using HCL2 by default so this field is no longer used and may be safely removed from your configuration files. Set 'hcl1 = true' if you must use HCL1 job parsing.",
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     false,
@@ -108,6 +109,13 @@ func resourceJob() *schema.Resource {
 						},
 					},
 				},
+			},
+
+			"hcl1": {
+				Description: "If true, the `jobspec` will be parsed using the HCL1 format.",
+				Optional:    true,
+				Default:     false,
+				Type:        schema.TypeBool,
 			},
 
 			"json": {
@@ -298,6 +306,7 @@ func taskGroupSchema() *schema.Schema {
 // JobParserConfig stores configuration options for how to parse the jobspec.
 type JobParserConfig struct {
 	JSON JSONJobParserConfig
+	HCL1 HCL1JobParserConfig
 	HCL2 HCL2JobParserConfig
 }
 
@@ -306,9 +315,13 @@ type JSONJobParserConfig struct {
 	Enabled bool
 }
 
+// HCL1JobParserConfig stores configuration options for the HCL1 jobspec parser.
+type HCL1JobParserConfig struct {
+	Enabled bool
+}
+
 // HCL2JobParserConfig stores configuration options for the HCL2 jobspec parser.
 type HCL2JobParserConfig struct {
-	Enabled bool
 	AllowFS bool
 	Vars    map[string]string
 }
@@ -718,6 +731,12 @@ func parseJobParserConfig(d ResourceFieldGetter) (JobParserConfig, error) {
 		Enabled: jsonEnabled,
 	}
 
+	// Read HCL1 parser configuration.
+	hclEnabled := d.Get("hcl1").(bool)
+	config.HCL1 = HCL1JobParserConfig{
+		Enabled: hclEnabled,
+	}
+
 	// Read HCL2 parser configuration.
 	hcl2Config, err := parseHCL2JobParserConfig(d.Get("hcl2"))
 	if err != nil {
@@ -725,9 +744,9 @@ func parseJobParserConfig(d ResourceFieldGetter) (JobParserConfig, error) {
 	}
 	config.HCL2 = hcl2Config
 
-	// JSON and HCL2 parsing are conflicting options.
-	if config.JSON.Enabled && config.HCL2.Enabled {
-		return config, fmt.Errorf("invalid combination. json is %t and hcl2.enabled is %t", config.JSON.Enabled, config.HCL2.Enabled)
+	// JSON and HCL1 parsing are conflicting options.
+	if config.JSON.Enabled && config.HCL1.Enabled {
+		return config, fmt.Errorf("invalid combination. json is %t and hcl1 is %t", config.JSON.Enabled, config.HCL1.Enabled)
 	}
 
 	return config, nil
@@ -754,9 +773,6 @@ func parseHCL2JobParserConfig(raw interface{}) (HCL2JobParserConfig, error) {
 	}
 
 	// Read map fields into parser config struct.
-	if enabled, ok := hcl2Map["enabled"].(bool); ok {
-		config.Enabled = enabled
-	}
 	if allowFS, ok := hcl2Map["allow_fs"].(bool); ok {
 		config.AllowFS = allowFS
 	}
@@ -777,10 +793,10 @@ func parseJobspec(raw string, config JobParserConfig, vaultToken *string, consul
 	switch {
 	case config.JSON.Enabled:
 		job, err = parseJSONJobspec(raw)
-	case config.HCL2.Enabled:
-		job, err = parseHCL2Jobspec(raw, config.HCL2)
-	default:
+	case config.HCL1.Enabled:
 		job, err = jobspec.Parse(strings.NewReader(raw))
+	default:
+		job, err = parseHCL2Jobspec(raw, config.HCL2)
 	}
 
 	if err != nil {
@@ -933,12 +949,12 @@ func jobspecDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	case jobParserConfig.JSON.Enabled:
 		oldJob, oldErr = parseJSONJobspec(old)
 		newJob, newErr = parseJSONJobspec(new)
-	case jobParserConfig.HCL2.Enabled:
-		oldJob, oldErr = parseHCL2Jobspec(old, jobParserConfig.HCL2)
-		newJob, newErr = parseHCL2Jobspec(new, jobParserConfig.HCL2)
-	default:
+	case jobParserConfig.HCL1.Enabled:
 		oldJob, oldErr = jobspec.Parse(strings.NewReader(old))
 		newJob, newErr = jobspec.Parse(strings.NewReader(new))
+	default:
+		oldJob, oldErr = parseHCL2Jobspec(old, jobParserConfig.HCL2)
+		newJob, newErr = parseHCL2Jobspec(new, jobParserConfig.HCL2)
 	}
 	if oldErr != nil {
 		log.Println("error parsing old jobspec")

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -93,21 +93,21 @@ API endpoint.
 
 ## HCL2 jobspec
 
-The input jobspec can also be provided in the [HCL2 format](https://www.nomadproject.io/docs/job-specification/hcl2)
-by enabling `hcl2` parsing:
+By default, HCL jobs are parsed using the [HCL2 format](https://www.nomadproject.io/docs/job-specification/hcl2).
+If your job is not compatible with HCL2 you may set the `hcl1` argument to
+`true` to use the previous HCL1 parser.
 
 ```hcl
 resource "nomad_job" "app" {
   jobspec = file("${path.module}/jobspec.hcl")
 
-  hcl2 {
-    enabled = true
-  }
+  hcl1 = true
 }
 ```
 
--> **Note:** This option should be enabled whenever possible as it includes
-   support for newer jobspec entries.
+-> **Note:** HCL1 parsing is only provided for backwards compatibility with
+  older jobspecs and may not support newer job features and functionalities, so
+  it should be avoided whenever possible.
 
 ### Variables
 
@@ -126,7 +126,6 @@ values must be provided as strings.
 ```hcl
 resource "nomad_job" "app" {
   hcl2 {
-    enabled  = true
     vars = {
       "restart_attempts" = "5",
       "datacenters"      = "[\"dc1\", \"dc2\"]",
@@ -176,7 +175,6 @@ job "example" {
 EOT
 
   hcl2 {
-    enabled  = true
     vars = {
       datacenter = random_pet.random_dc.id
     }
@@ -192,10 +190,6 @@ job "example" {
   ...
 }
 EOT
-
-  hcl2 {
-    enabled  = true
-  }
 }
 ```
 
@@ -216,7 +210,6 @@ resource "nomad_job" "app" {
   jobspec = file("${path.module}/jobspec.hcl")
 
   hcl2 {
-    enabled  = true
     allow_fs = true
   }
 }
@@ -280,9 +273,13 @@ The following arguments are supported:
 - `json` `(boolean: false)` - Set this to `true` if your jobspec is structured with
   JSON instead of the default HCL.
 
+- `hcl1` `(boolean: false)` - Set this to `true` to use the previous HCL1
+  parser. This option is provided for backwards compatibility only and should
+  not be used unless absolutely necessary.
+
 - `hcl2` `(block: optional)` - Options for the HCL2 jobspec parser.
-  - `enabled` `(boolean: false)` - Set this to `true` if your jobspec uses the HCL2
-    format instead of the default HCL.
+  - `enabled` `(boolean: false)` - **Deprecated** All HCL jobs are parsed as
+    HCL2 by default.
   - `allow_fs` `(boolean: false)` - Set this to `true` to be able to use
     [HCL2 filesystem functions](#filesystem-functions)
 


### PR DESCRIPTION
Parsing with HCL2 is the default behaviour of the Nomad CLI and so this change aims to make their behaviour the same.

The new `hcl1` attribute is provided for backwards compatibility to also match the Nomad CLI, which has the `-hcl1` flag.