### PR TITLE
volumes: add timeout and retry on create and delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ IMPROVEMENTS:
 * provider: add `skip_verify` configuration to skip TLS verification ([#319](https://github.com/hashicorp/terraform-provider-nomad/pull/319))
 * provider: update Go to 1.20.5 ([#334](https://github.com/hashicorp/terraform-provider-nomad/pull/334))
 * resource/nomad_acl_policy: add support for `job_acl` ([#314](https://github.com/hashicorp/terraform-provider-nomad/pull/314))
+* resource/nomad_volume and resource/nomad_external_volume: add timeouts for volume creation, registration, deregistration, and deletion ([#346](https://github.com/hashicorp/terraform-provider-nomad/pull/346))
 
 BUG FIXES:
 * data source/acl_auth_method: fix a bug where the values of `max_token_ttl` and `discovery_ca_pem` were not persisted to state. ([#339](https://github.com/hashicorp/terraform-provider-nomad/issues/339))

--- a/website/docs/r/csi_volume.html.markdown
+++ b/website/docs/r/csi_volume.html.markdown
@@ -120,3 +120,13 @@ can be referenced:
 - `nodes_expected`: `(integer)`
 - `schedulable`: `(boolean)`
 - `topologies`: `(List of topologies)`
+
+### Timeouts
+
+`nomad_csi_volume` provides the following [`Timeouts`][tf_docs_timeouts]
+configuration options.
+
+- `create` `(string: "15m")` - Timeout when creating or updating a new CSI volume.
+- `delete` `(string: "15m")` - Timeout when deleting a CSI volume .
+
+[tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts

--- a/website/docs/r/csi_volume.html.markdown
+++ b/website/docs/r/csi_volume.html.markdown
@@ -126,7 +126,7 @@ can be referenced:
 `nomad_csi_volume` provides the following [`Timeouts`][tf_docs_timeouts]
 configuration options.
 
-- `create` `(string: "15m")` - Timeout when creating or updating a new CSI volume.
-- `delete` `(string: "15m")` - Timeout when deleting a CSI volume .
+- `create` `(string: "10m")` - Timeout when creating or updating a new CSI volume.
+- `delete` `(string: "10m")` - Timeout when deleting a CSI volume.
 
 [tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts

--- a/website/docs/r/csi_volume_registration.html.markdown
+++ b/website/docs/r/csi_volume_registration.html.markdown
@@ -119,3 +119,13 @@ can be referenced:
 - `nodes_expected`: `(integer)`
 - `schedulable`: `(boolean)`
 - `topologies`: `(List of topologies)`
+
+### Timeouts
+
+`nomad_csi_volume_registration` provides the following
+[`Timeouts`][tf_docs_timeouts] configuration options.
+
+- `create` `(string: "15m")` - Timeout when registering a new CSI volume.
+- `delete` `(string: "15m")` - Timeout when deregistering a CSI volume .
+
+[tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts

--- a/website/docs/r/csi_volume_registration.html.markdown
+++ b/website/docs/r/csi_volume_registration.html.markdown
@@ -125,7 +125,7 @@ can be referenced:
 `nomad_csi_volume_registration` provides the following
 [`Timeouts`][tf_docs_timeouts] configuration options.
 
-- `create` `(string: "15m")` - Timeout when registering a new CSI volume.
-- `delete` `(string: "15m")` - Timeout when deregistering a CSI volume .
+- `create` `(string: "10m")` - Timeout when registering a new CSI volume.
+- `delete` `(string: "10m")` - Timeout when deregistering a CSI volume.
 
 [tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts

--- a/website/docs/r/external_volume.html.markdown
+++ b/website/docs/r/external_volume.html.markdown
@@ -124,3 +124,13 @@ can be referenced:
 - `nodes_expected`: `(integer)`
 - `schedulable`: `(boolean)`
 - `topologies`: `(List of topologies)`
+
+### Timeouts
+
+`nomad_external_volume` provides the following [`Timeouts`][tf_docs_timeouts]
+configuration options.
+
+- `create` `(string: "15m")` - Timeout when creating or updating a new volume.
+- `delete` `(string: "15m")` - Timeout when deleting a volume .
+
+[tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts

--- a/website/docs/r/external_volume.html.markdown
+++ b/website/docs/r/external_volume.html.markdown
@@ -130,7 +130,7 @@ can be referenced:
 `nomad_external_volume` provides the following [`Timeouts`][tf_docs_timeouts]
 configuration options.
 
-- `create` `(string: "15m")` - Timeout when creating or updating a new volume.
-- `delete` `(string: "15m")` - Timeout when deleting a volume .
+- `create` `(string: "10m")` - Timeout when creating or updating a new volume.
+- `delete` `(string: "10m")` - Timeout when deleting a volume.
 
 [tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -134,7 +134,7 @@ can be referenced:
 `nomad_volume` provides the following [`Timeouts`][tf_docs_timeouts]
 configuration options.
 
-- `create` `(string: "15m")` - Timeout when registering a new volume.
-- `delete` `(string: "15m")` - Timeout when deregistering a volume .
+- `create` `(string: "10m")` - Timeout when registering a new volume.
+- `delete` `(string: "10m")` - Timeout when deregistering a volume.
 
 [tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -128,3 +128,13 @@ can be referenced:
 - `nodes_expected`: `(integer)`
 - `schedulable`: `(boolean)`
 - `topologies`: `(List of topologies)`
+
+### Timeouts
+
+`nomad_volume` provides the following [`Timeouts`][tf_docs_timeouts]
+configuration options.
+
+- `create` `(string: "15m")` - Timeout when registering a new volume.
+- `delete` `(string: "15m")` - Timeout when deregistering a volume .
+
+[tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts


### PR DESCRIPTION
Add retry logic during volume create, register, deregister and delete.

Update deprecated resources since the deprecation has not happen yet, so keep them updated until v2.0.0 is out.

Closes https://github.com/hashicorp/terraform-provider-nomad/issues/335