### PR TITLE
volume: fix nil retryable error

### DIFF
--- a/nomad/data_source_node_pool_test.go
+++ b/nomad/data_source_node_pool_test.go
@@ -36,7 +36,7 @@ func TestDataSourceNodePool(t *testing.T) {
 					resource.TestCheckResourceAttr("data.nomad_node_pool.test", "description", "Terraform test node pool"),
 					resource.TestCheckResourceAttr("data.nomad_node_pool.test", "meta.%", "1"),
 					resource.TestCheckResourceAttr("data.nomad_node_pool.test", "meta.test", "true"),
-					resource.TestCheckNoResourceAttr("data.nomad_node_pool.test", "scheduler_config"),
+					resource.TestCheckResourceAttr("data.nomad_node_pool.test", "scheduler_config.#", "0"),
 				),
 			},
 		},

--- a/nomad/resource_csi_volume.go
+++ b/nomad/resource_csi_volume.go
@@ -402,7 +402,12 @@ func resourceCSIVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] CSI volume %q created in namespace %q", volume.ID, volume.Namespace)
 		d.SetId(volume.ID)
 
-		return retry.RetryableError(resourceCSIVolumeRead(d, meta)) // populate other computed attributes
+		err := resourceCSIVolumeRead(d, meta) // populate other computed attributes
+		if err != nil {
+			return retry.RetryableError(err)
+		}
+
+		return nil
 	})
 }
 

--- a/nomad/resource_csi_volume_registration.go
+++ b/nomad/resource_csi_volume_registration.go
@@ -359,7 +359,12 @@ func resourceCSIVolumeRegistrationCreate(d *schema.ResourceData, meta interface{
 		log.Printf("[DEBUG] CSI volume %q registered in namespace %q", volume.ID, volume.Namespace)
 		d.SetId(volume.ID)
 
-		return retry.RetryableError(resourceCSIVolumeRead(d, meta)) // populate other computed attributes
+		err := resourceCSIVolumeRead(d, meta) // populate other computed attributes
+		if err != nil {
+			return retry.RetryableError(err)
+		}
+
+		return nil
 	})
 }
 

--- a/nomad/resource_external_volume.go
+++ b/nomad/resource_external_volume.go
@@ -415,7 +415,12 @@ func resourceExternalVolumeCreate(d *schema.ResourceData, meta interface{}) erro
 		log.Printf("[DEBUG] volume %q created in namespace %q", volume.ID, volume.Namespace)
 		d.SetId(volume.ID)
 
-		return retry.RetryableError(resourceVolumeRead(d, meta)) // populate other computed attributes
+		err := resourceVolumeRead(d, meta) // populate other computed attributes
+		if err != nil {
+			return retry.RetryableError(err)
+		}
+
+		return nil
 	})
 }
 

--- a/nomad/resource_volume.go
+++ b/nomad/resource_volume.go
@@ -452,7 +452,12 @@ func resourceVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] volume %q registered in namespace %q", volume.ID, volume.Namespace)
 		d.SetId(volume.ID)
 
-		return retry.RetryableError(resourceVolumeRead(d, meta)) // populate other computed attributes
+		err := resourceVolumeRead(d, meta) // populate other computed attributes
+		if err != nil {
+			return retry.RetryableError(err)
+		}
+
+		return nil
 	})
 }
 


### PR DESCRIPTION
Prevent errors of kind `Error: empty retryable error received.`

Sample error: https://github.com/hashicorp/terraform-provider-nomad/actions/runs/5600076107/job/15169538864#step:8:118

No changelog since this change has not been released.