### PR TITLE
namespace: add node pool configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ IMPROVEMENTS:
 * **Target Nomad 1.6.0*: updated the nomad client to support Nomad API and jobspec version 1.6.0 ([#345](https://github.com/hashicorp/terraform-provider-nomad/pull/345))
 * provider: add `skip_verify` configuration to skip TLS verification ([#319](https://github.com/hashicorp/terraform-provider-nomad/pull/319))
 * provider: update Go to 1.20.5 ([#334](https://github.com/hashicorp/terraform-provider-nomad/pull/334))
+* data source/nomad_namespace: add `node_pool_config` attribute ([#355](https://github.com/hashicorp/terraform-provider-nomad/pull/355))
 * resource/nomad_acl_policy: add support for `job_acl` ([#314](https://github.com/hashicorp/terraform-provider-nomad/pull/314))
 * resource/nomad_csi_volume and resource/nomad_csi_volume_registration: add support to import existing volumes. ([#359](https://github.com/hashicorp/terraform-provider-nomad/pull/359)]
 * resource/nomad_job: add support to import existing jobs. ([#359](https://github.com/hashicorp/terraform-provider-nomad/pull/359)]
-* resource/nomad_namespace data source/nomad_namespace: add `node_pool_config` attribute ([#355](https://github.com/hashicorp/terraform-provider-nomad/pull/355))
+* resource/nomad_namespace: add `node_pool_config` attribute ([#355](https://github.com/hashicorp/terraform-provider-nomad/pull/355))
 * resource/nomad_volume and resource/nomad_external_volume: add timeouts for volume creation, registration, deregistration, and deletion ([#346](https://github.com/hashicorp/terraform-provider-nomad/pull/346))
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ IMPROVEMENTS:
 * resource/nomad_acl_policy: add support for `job_acl` ([#314](https://github.com/hashicorp/terraform-provider-nomad/pull/314))
 * resource/nomad_csi_volume and resource/nomad_csi_volume_registration: add support to import existing volumes. ([#359](https://github.com/hashicorp/terraform-provider-nomad/pull/359)]
 * resource/nomad_job: add support to import existing jobs. ([#359](https://github.com/hashicorp/terraform-provider-nomad/pull/359)]
+* resource/nomad_namespace data source/nomad_namespace: add `node_pool_config` attribute ([#355](https://github.com/hashicorp/terraform-provider-nomad/pull/355))
 * resource/nomad_volume and resource/nomad_external_volume: add timeouts for volume creation, registration, deregistration, and deletion ([#346](https://github.com/hashicorp/terraform-provider-nomad/pull/346))
 
 BUG FIXES:

--- a/nomad/data_source_namespace.go
+++ b/nomad/data_source_namespace.go
@@ -38,6 +38,32 @@ func dataSourceNamespace() *schema.Resource {
 				Computed: true,
 				Elem:     resourceNamespaceCapabilities(),
 			},
+			"node_pool_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"default": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"allowed": {
+							Computed: true,
+							Type:     schema.TypeSet,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"denied": {
+							Computed: true,
+							Type:     schema.TypeSet,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -62,6 +88,9 @@ func namespaceDataSourceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err = d.Set("capabilities", flattenNamespaceCapabilities(ns.Capabilities)); err != nil {
 		return fmt.Errorf("Failed to set 'capabilities': %v", err)
+	}
+	if err = d.Set("node_pool_config", flattenNamespaceNodePoolConfig(ns.NodePoolConfiguration)); err != nil {
+		return fmt.Errorf("Failed to set 'node_pool_config': %v", err)
 	}
 
 	d.SetId(client.Address() + "/namespace/" + name)

--- a/nomad/data_source_node_pool_test.go
+++ b/nomad/data_source_node_pool_test.go
@@ -16,7 +16,7 @@ func TestDataSourceNodePool(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0-beta.1") },
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0") },
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceNodePoolConfig_builtIn,
@@ -48,7 +48,7 @@ func TestDataSourceNodePool_schedConfig(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0-beta.1"); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0"); testCheckEnt(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceNodePoolConfig_schedConfig(name),

--- a/nomad/resource_node_pool_test.go
+++ b/nomad/resource_node_pool_test.go
@@ -21,7 +21,7 @@ func TestResourceNodePool_import(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0-beta.1") },
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0") },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceNodePoolConfig_basic(name),
@@ -41,7 +41,7 @@ func TestResourceNodePool_schedulerConfig(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0-beta.1"); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0"); testCheckEnt(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceNodePoolConfig_schedConfig(name),
@@ -56,7 +56,7 @@ func TestResourceNodePool_refresh(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0-beta.1") },
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0") },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceNodePoolConfig_basic(name),
@@ -78,7 +78,7 @@ func TestResourceNodePool_update(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0-beta.1"); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0"); testCheckEnt(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceNodePoolConfig_schedConfig(name),
@@ -96,7 +96,7 @@ func TestResourceNodePool_update(t *testing.T) {
 func TestResourceNodePool_error(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0-beta.1") },
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.6.0") },
 		Steps: []resource.TestStep{
 			{
 				Config: `

--- a/scripts/getnomad.sh
+++ b/scripts/getnomad.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-NOMAD_VERSION='1.6.0-beta.1'
+NOMAD_VERSION='1.6.0'
 if [[ -n "$NOMAD_LICENSE" || -n "$NOMAD_LICENSE_PATH" ]]; then
     NOMAD_VERSION=${NOMAD_VERSION}+ent
 fi

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -63,8 +63,9 @@ The following arguments are supported:
 - `description` `(string: "")` - A description of the namespace.
 - `quota` `(string: "")` - A resource quota to attach to the namespace.
 - `meta` `(map[string]string: <optional>)` -  Specifies arbitrary KV metadata to associate with the namespace.
-- `capabilities` `(block: <optional>)` - A block of capabilities for the namespace. Can't 
+- `capabilities` `(block: <optional>)` - A block of capabilities for the namespace. Can't
   be repeated. See below for the structure of this block.
+- `node_pool_config` `(block: <optional>)` - A block with node pool configuration for the namespace (Nomad Enterprise only).
 
 
 ### `capabilities` blocks
@@ -74,3 +75,12 @@ the following arguments:
 
 - `enabled_task_drivers` `([]string: <optional>)` - Task drivers enabled for the namespace.
 - `disabled_task_drivers` `([]string: <optional>)` - Task drivers disabled for the namespace.
+
+### `node_pool_config` blocks
+
+The `node_pool_config` block describes the node pool configuration for the
+namespace.
+
+- `default` `(string: <optional>)` - The default node pool for jobs that don't define one.
+- `allowed` `([]string: <optional>)` - The list of node pools that are allowed to be used in this namespace.
+- `denied` `([]string: <optional>)` - The list of node pools that are not allowed to be used in this namespace.


### PR DESCRIPTION
Add `node_pool_config` to `namespace` resource and data source.

Broken tests fixed in #354

Closes https://github.com/hashicorp/terraform-provider-nomad/issues/352