### PR TITLE
resource/job: use semantic jobspec diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ BUG FIXES:
 * data source/nomad_volume: fix panic when reading volume ([#323](https://github.com/hashicorp/terraform-provider-nomad/pull/323))
 * resources/nomad_acl_binding_rule: fix a bug where `bind_name` was required even when `bind_type` was `management`. ([#330](https://github.com/hashicorp/terraform-provider-nomad/pull/330))
 * resources/nomad_job: fix a bug that prevented deployments for jobs in namespaces other than `default` from being monitored. ([#347](https://github.com/hashicorp/terraform-provider-nomad/pull/347))
+* resource/nomad_job: fix a bug that could result in unnecessary plan diffs from irrelevant changes. ([#356](https://github.com/hashicorp/terraform-provider-nomad/pull/356))
 * resource/nomad_volume and resource/nomad_external_volume: fix a bug where `topology_request` was not persisted to state. ([#342](https://github.com/hashicorp/terraform-provider-nomad/pull/342)
 
 ## 1.4.20 (April 20, 2023)

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -626,7 +626,7 @@ func resourceJobCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta in
 
 	oldSpecRaw, newSpecRaw := d.GetChange("jobspec")
 
-	if oldSpecRaw.(string) == newSpecRaw.(string) {
+	if jobspecEqual("jobspec", oldSpecRaw.(string), newSpecRaw.(string), d) {
 		// nothing to do!
 		return nil
 	}
@@ -937,6 +937,10 @@ func jobTaskGroupsRaw(tgs []*api.TaskGroup) []interface{} {
 // jobspecDiffSuppress is the DiffSuppressFunc used by the schema to
 // check if two jobspecs are equal.
 func jobspecDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return jobspecEqual(k, old, new, d)
+}
+
+func jobspecEqual(k, old, new string, d ResourceFieldGetter) bool {
 	var oldJob *api.Job
 	var newJob *api.Job
 	var oldErr error


### PR DESCRIPTION
The previous implementation of the custom jobspec diff used a naive string equality check, which can result in unnecessary plan diffs due to inconsequential changes, like comments or spaces being added/removed.

By reusing the same logic as the `jobspec` field diff we compare the job struct as it would be submitted to the Nomad API.

Closes #349
Closes #290