### PR TITLE
resource/job: remove attribute allocation_ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 BACKWARDS INCOMPATIBILITIES:
 * provider: Terraform Plugin SDK upgraded to v2.10.1. **Terraform versions prior to 0.12 are no longer supported.** ([#339](https://github.com/hashicorp/terraform-provider-nomad/issues/339))
 * resource/nomad_job: Switch to HCL2 parsing by default. Jobs that require HCL1 parsing must set `hcl1 = true`. ([#343](https://github.com/hashicorp/terraform-provider-nomad/pull/343))
+* resource/nomad_job: Deprecate field `allocation_ids` and do not retrieve the job's allocations by default. Set `read_allocation_ids` to `true` if you must retain existing behavior, but consider using the `nomad_allocations` data source instead. ([#357](https://github.com/hashicorp/terraform-provider-nomad/pull/357))
 
 DEPRECATIONS:
 * resource/nomad_volume: The `nomad_volume` resource has been deprecated. Use the new `nomad_csi_volume_registration` resource instead. ([#344](https://github.com/hashicorp/terraform-provider-nomad/pull/344))

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -187,7 +186,6 @@ func TestResourceJob_batchNoDetach(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "deployment_status", ""),
-					resource.TestCheckResourceAttrSet(resourceName, "allocation_ids.#"),
 				),
 			},
 		},
@@ -1185,24 +1183,6 @@ func testResourceJob_initialCheckNS(t *testing.T, expectedNamespace string) r.Te
 
 		if got, want := *job.Namespace, expectedNamespace; got != want {
 			return fmt.Errorf("job namespace is %q; want %q", got, want)
-		}
-
-		wantAllocs, _, err := client.Jobs().Allocations(jobID, false, nil)
-		if err != nil {
-			return fmt.Errorf("error reading back job: %s", err)
-		}
-		wantAllocIds := make([]string, 0, len(wantAllocs))
-		for _, a := range wantAllocs {
-			wantAllocIds = append(wantAllocIds, a.ID)
-		}
-		numGotAllocs, _ := strconv.Atoi(instanceState.Attributes["allocation_ids.#"])
-		gotAllocs := make([]string, 0, numGotAllocs)
-		for i := 0; i < numGotAllocs; i++ {
-			id := instanceState.Attributes[fmt.Sprintf("allocation_ids.%d", i)]
-			gotAllocs = append(gotAllocs, id)
-		}
-		if !assert.ElementsMatch(t, gotAllocs, wantAllocIds) {
-			return fmt.Errorf("job 'allocation_ids' is '%v'; want '%v'", gotAllocs, wantAllocIds)
 		}
 
 		return nil


### PR DESCRIPTION
Storing the list of allocation IDs in a `nomad_job` resource can lead to ever-changing plans since the list can change outsite of Terraform.

Retrieving this type of information is better suited for a data source.

The Terraform provider deprecation guide recommends attributes to be first marked as deprecated before full removal in the next major release.

Given that the next release will be a major release, this commit introduces a breaking change in behaviour (allocation IDs are not fetched by default anymore) but provides a fallback with the `read_allocation_ids` attribute.

Both attributes are marked as deprecated and will be removed in the next major release.

`nomad_allocations` data source added in https://github.com/hashicorp/terraform-provider-nomad/pull/358