### PR TITLE
volumes: fix capacity parsing to allow optional values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ BUG FIXES:
 * resources/nomad_acl_binding_rule: fix a bug where `bind_name` was required even when `bind_type` was `management`. ([#330](https://github.com/hashicorp/terraform-provider-nomad/pull/330))
 * resources/nomad_job: fix a bug that prevented deployments for jobs in namespaces other than `default` from being monitored. ([#347](https://github.com/hashicorp/terraform-provider-nomad/pull/347))
 * resource/nomad_job: fix a bug that could result in unnecessary plan diffs from irrelevant changes. ([#356](https://github.com/hashicorp/terraform-provider-nomad/pull/356))
+* resource/nomad_volume: fix a bug that caused `capacity_min` and `capacity_max` to be mandatory. ([#363](https://github.com/hashicorp/terraform-provider-nomad/pull/363))
 * resource/nomad_volume and resource/nomad_external_volume: fix a bug where `topology_request` was not persisted to state. ([#342](https://github.com/hashicorp/terraform-provider-nomad/pull/342)
 
 ## 1.4.20 (April 20, 2023)

--- a/nomad/resource_csi_volume.go
+++ b/nomad/resource_csi_volume.go
@@ -328,14 +328,22 @@ func resourceCSIVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 	client := providerConfig.client
 
 	// Parse capacities from human-friendly string to number.
-	capacityMin, err := humanize.ParseBytes(d.Get("capacity_min").(string))
-	if err != nil {
-		return fmt.Errorf("invalid value 'capacity_min': %v", err)
+	var capacityMin uint64
+	if capacityMinStr := d.Get("capacity_min").(string); capacityMinStr != "" {
+		var err error
+		capacityMin, err = humanize.ParseBytes(capacityMinStr)
+		if err != nil {
+			return fmt.Errorf("invalid value 'capacity_min': %v", err)
+		}
 	}
 
-	capacityMax, err := humanize.ParseBytes(d.Get("capacity_max").(string))
-	if err != nil {
-		return fmt.Errorf("invalid value 'capacity_max': %v", err)
+	var capacityMax uint64
+	if capacityMaxStr := d.Get("capacity_max").(string); capacityMaxStr != "" {
+		var err error
+		capacityMax, err = humanize.ParseBytes(capacityMaxStr)
+		if err != nil {
+			return fmt.Errorf("invalid value 'capacity_max': %v", err)
+		}
 	}
 
 	// Parse capabilities set.

--- a/nomad/resource_external_volume.go
+++ b/nomad/resource_external_volume.go
@@ -337,14 +337,22 @@ func resourceExternalVolumeCreate(d *schema.ResourceData, meta interface{}) erro
 	client := providerConfig.client
 
 	// Parse capacities from human-friendly string to number.
-	capacityMin, err := humanize.ParseBytes(d.Get("capacity_min").(string))
-	if err != nil {
-		return fmt.Errorf("invalid value 'capacity_min': %v", err)
+	var capacityMin uint64
+	if capacityMinStr := d.Get("capacity_min").(string); capacityMinStr != "" {
+		var err error
+		capacityMin, err = humanize.ParseBytes(capacityMinStr)
+		if err != nil {
+			return fmt.Errorf("invalid value 'capacity_min': %v", err)
+		}
 	}
 
-	capacityMax, err := humanize.ParseBytes(d.Get("capacity_max").(string))
-	if err != nil {
-		return fmt.Errorf("invalid value 'capacity_max': %v", err)
+	var capacityMax uint64
+	if capacityMaxStr := d.Get("capacity_max").(string); capacityMaxStr != "" {
+		var err error
+		capacityMax, err = humanize.ParseBytes(capacityMaxStr)
+		if err != nil {
+			return fmt.Errorf("invalid value 'capacity_max': %v", err)
+		}
 	}
 
 	// Parse capabilities set.


### PR DESCRIPTION
Allow `capacity_min` and `capacity_max` to actually be optional values.

Closes https://github.com/hashicorp/terraform-provider-nomad/issues/362