### PR TITLE
Docs: Corrected nomad_acl_auth_method docs page heading 

### DIFF
--- a/website/docs/r/acl_auth_method.html.markdown
+++ b/website/docs/r/acl_auth_method.html.markdown
@@ -6,7 +6,7 @@ description: |-
 Manages an ACL Auth Method in Nomad.
 ---
 
-# nomad_acl_binding_rule
+# nomad_acl_auth_method
 
 Manages an ACL Auth Method in Nomad.
 


### PR DESCRIPTION
This PR corrects the heading for the `nomad_acl_auth_method` resource on the docs page.