### PR TITLE
resource/job: set namespace on register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
 BUG FIXES:
 * resource/nomad_acl_policy: fixed a bug where the namespace would be incorrectly calculated from a job identity ([#396](https://github.com/hashicorp/terraform-provider-nomad/pull/396))
 * resource/nomad_csi_volume_registration: fixed a bug that cause an import operation to not load all of the volume attributes ([#402](https://github.com/hashicorp/terraform-provider-nomad/pull/402))
+* resource/nomad_job: fixed a bug that could cause jobs to be registered in the incorrect namespace if the `NOMAD_NAMESPACE` environment variable is set ([#386](https://github.com/hashicorp/terraform-provider-nomad/pull/386))
 * resource/nomad_volume: fixed a bug that cause an import operation to not load all of the volume attributes ([#402](https://github.com/hashicorp/terraform-provider-nomad/pull/402))
 
 ## 2.0.0 (August 28th, 2023)

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -399,12 +399,11 @@ func resourceJobRegister(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		wantModifyIndex = 0
 	}
-	ns := *job.Namespace
 	resp, _, err := client.Jobs().RegisterOpts(job, &api.RegisterOptions{
 		PolicyOverride: d.Get("policy_override").(bool),
 		ModifyIndex:    wantModifyIndex,
 	}, &api.WriteOptions{
-		Namespace: ns,
+		Namespace: *job.Namespace,
 	})
 	if err != nil {
 		return fmt.Errorf("error applying jobspec: %s", err)
@@ -697,7 +696,9 @@ func resourceJobCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta in
 	resp, _, err := client.Jobs().PlanOpts(job, &api.PlanOptions{
 		Diff:           false,
 		PolicyOverride: d.Get("policy_override").(bool),
-	}, nil)
+	}, &api.WriteOptions{
+		Namespace: *job.Namespace,
+	})
 	if err != nil {
 		log.Printf("[WARN] failed to validate Nomad plan: %s", err)
 	}

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -399,11 +399,13 @@ func resourceJobRegister(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		wantModifyIndex = 0
 	}
-
+	ns := *job.Namespace
 	resp, _, err := client.Jobs().RegisterOpts(job, &api.RegisterOptions{
 		PolicyOverride: d.Get("policy_override").(bool),
 		ModifyIndex:    wantModifyIndex,
-	}, nil)
+	}, &api.WriteOptions{
+		Namespace: ns,
+	})
 	if err != nil {
 		return fmt.Errorf("error applying jobspec: %s", err)
 	}


### PR DESCRIPTION
When register jobs by Http api need to set the job namespace in the request.

coder/coder#10074