### PR TITLE
fix typo bug in acl_policy resource for job_acl namespace field

### DIFF
--- a/nomad/resource_acl_policy.go
+++ b/nomad/resource_acl_policy.go
@@ -92,7 +92,7 @@ func parseWorkloadIdentity(workloadIdentity interface{}) (*api.JobACL, error) {
 	}
 
 	var namespace, jobID, group, task string
-	if val, ok := jobACL["namepace"].(string); ok {
+	if val, ok := jobACL["namespace"].(string); ok {
 		namespace = val
 	}
 


### PR DESCRIPTION
the effect of this bug is that the job_acl namespace is always set to "default" regardless of input