### PR TITLE
ci: skip log upload on test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,16 +41,16 @@ jobs:
         run: |
           sudo chmod -R 777 /tmp/nomad
           sudo chmod 666 /tmp/nomad.log
-      - name: Upload logs
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        if: always()
-        with:
-          name: logs
-          path: |
-            /tmp/consul.log
-            /tmp/nomad.log
-            /tmp/vault.log
-            /tmp/nomad/data/**/alloc/logs/plugin*
-            !/tmp/nomad/data/**/alloc/logs/*.fifo
-          if-no-files-found: warn
-          retention-days: 3
+    # - name: Upload logs
+    #   uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+    #   if: always()
+    #   with:
+    #     name: logs
+    #     path: |
+    #       /tmp/consul.log
+    #       /tmp/nomad.log
+    #       /tmp/vault.log
+    #       /tmp/nomad/data/**/alloc/logs/plugin*
+    #       !/tmp/nomad/data/**/alloc/logs/*.fifo
+    #     if-no-files-found: warn
+    #     retention-days: 3


### PR DESCRIPTION
For some reason GitHub Actions started to get stuck on log update. I have not been able to debug exactly why, so just skipping this step for now.