### PR TITLE
job: import jobs from non-default namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
 * resource/nomad_csi_volume: changes to `capacity_min` or `capacity_max` may now expand the volume instead of forcing replacement,
   on Nomad version 1.6.3 or later, if the CSI plugin supports it ([#382](https://github.com/hashicorp/terraform-provider-nomad/pull/382))
 * resource/nomad_job: Add `rerun_if_dead` attribute to allow forcing a job to run again if it's marked as `dead`. ([#407](https://github.com/hashicorp/terraform-provider-nomad/pull/407))
+* resource/nomad_job: add support for importing jobs from non-default namespace ([#408](https://github.com/hashicorp/terraform-provider-nomad/pull/408))
 
 BUG FIXES:
 * resource/nomad_acl_policy: fixed a bug where the namespace would be incorrectly calculated from a job identity ([#396](https://github.com/hashicorp/terraform-provider-nomad/pull/396))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ IMPROVEMENTS:
 * provider: update Go to 1.21.5 ([#399](https://github.com/hashicorp/terraform-provider-nomad/pull/399))
 * resource/resource_acl_auth_method: add support for `token_name_format` ([#403](https://github.com/hashicorp/terraform-provider-nomad/pull/403))
 * resource/nomad_csi_volume: changes to `capacity_min` or `capacity_max` may now expand the volume instead of forcing replacement,
+* resource/nomad_csi_volume: update import key to be `<volume id>@<namespace>` to allow importing volumes from namespaces other than `default` ([#408](https://github.com/hashicorp/terraform-provider-nomad/pull/408))
+* resource/nomad_csi_volume_registration: update import key to be `<volume id>@<namespace>` to allow importing volume registrations from namespaces other than `default` ([#408](https://github.com/hashicorp/terraform-provider-nomad/pull/408))
   on Nomad version 1.6.3 or later, if the CSI plugin supports it ([#382](https://github.com/hashicorp/terraform-provider-nomad/pull/382))
 * resource/nomad_job: Add `rerun_if_dead` attribute to allow forcing a job to run again if it's marked as `dead`. ([#407](https://github.com/hashicorp/terraform-provider-nomad/pull/407))
-* resource/nomad_job: add support for importing jobs from non-default namespace ([#408](https://github.com/hashicorp/terraform-provider-nomad/pull/408))
+* resource/nomad_job: update import key to be `<job id>@<namespace>` to allow importing jobs from namespaces other than `default` ([#408](https://github.com/hashicorp/terraform-provider-nomad/pull/408))
 
 BUG FIXES:
 * resource/nomad_acl_policy: fixed a bug where the namespace would be incorrectly calculated from a job identity ([#396](https://github.com/hashicorp/terraform-provider-nomad/pull/396))

--- a/nomad/helper/import.go
+++ b/nomad/helper/import.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package helper
 
 import (

--- a/nomad/helper/import.go
+++ b/nomad/helper/import.go
@@ -20,7 +20,7 @@ var (
 // its namespace as part of the Terraform resource ID.
 func NamespacedImporterContext(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	namespacedID := d.Id()
-	sepIdx := strings.LastIndex(d.Id(), "@")
+	sepIdx := strings.LastIndex(namespacedID, "@")
 	if sepIdx == -1 {
 		return nil, missingNamespaceImportErr
 	}

--- a/nomad/helper/import.go
+++ b/nomad/helper/import.go
@@ -1,0 +1,27 @@
+package helper
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// NamespacedImporter returns a function that can be used to import resources
+// where the namespace is not included in the resource ID.
+func NamespacedImporter(readFunc schema.ReadFunc) schema.StateContextFunc {
+	return func(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+		namespacedID := d.Id()
+		sepIdx := strings.LastIndex(d.Id(), "@")
+		if sepIdx == -1 {
+			readFunc(d, meta)
+			return []*schema.ResourceData{d}, nil
+		}
+
+		d.SetId(namespacedID[:sepIdx])
+		d.Set("namespace", namespacedID[sepIdx+1:])
+
+		readFunc(d, meta)
+		return []*schema.ResourceData{d}, nil
+	}
+}

--- a/nomad/helper/import.go
+++ b/nomad/helper/import.go
@@ -5,26 +5,38 @@ package helper
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// NamespacedImporter returns a function that can be used to import resources
-// where the namespace is not included in the resource ID.
-func NamespacedImporter(readFunc schema.ReadFunc) schema.StateContextFunc {
-	return func(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-		namespacedID := d.Id()
-		sepIdx := strings.LastIndex(d.Id(), "@")
-		if sepIdx == -1 {
-			readFunc(d, meta)
-			return []*schema.ResourceData{d}, nil
-		}
+var (
+	missingNamespaceImportErr = errors.New("missing namespace, the import ID should follow the pattern <id>@<namespace>")
+	missingIDImportErr        = errors.New("missing resource ID, the import ID should follow the pattern <id>@<namespace>")
+)
 
-		d.SetId(namespacedID[:sepIdx])
-		d.Set("namespace", namespacedID[sepIdx+1:])
-
-		readFunc(d, meta)
-		return []*schema.ResourceData{d}, nil
+// NamespacedImporterContext imports a namespaced resource that doesn't have
+// its namespace as part of the Terraform resource ID.
+func NamespacedImporterContext(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	namespacedID := d.Id()
+	sepIdx := strings.LastIndex(d.Id(), "@")
+	if sepIdx == -1 {
+		return nil, missingNamespaceImportErr
 	}
+
+	ns := namespacedID[sepIdx+1:]
+	if len(ns) == 0 {
+		return nil, missingNamespaceImportErr
+	}
+
+	id := namespacedID[:sepIdx]
+	if len(id) == 0 {
+		return nil, missingIDImportErr
+	}
+
+	d.SetId(id)
+	d.Set("namespace", ns)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/nomad/resource_csi_volume.go
+++ b/nomad/resource_csi_volume.go
@@ -34,7 +34,7 @@ func resourceCSIVolume() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			StateContext: helper.NamespacedImporter(resourceCSIVolumeRead),
+			StateContext: helper.NamespacedImporterContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nomad/resource_csi_volume.go
+++ b/nomad/resource_csi_volume.go
@@ -34,7 +34,7 @@ func resourceCSIVolume() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: helper.NamespacedImporter(resourceCSIVolumeRead),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nomad/resource_csi_volume_registration.go
+++ b/nomad/resource_csi_volume_registration.go
@@ -35,7 +35,7 @@ func resourceCSIVolumeRegistration() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			StateContext: helper.NamespacedImporter(resourceCSIVolumeRegistrationRead),
+			StateContext: helper.NamespacedImporterContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nomad/resource_csi_volume_registration.go
+++ b/nomad/resource_csi_volume_registration.go
@@ -35,7 +35,7 @@ func resourceCSIVolumeRegistration() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: helper.NamespacedImporter(resourceCSIVolumeRegistrationRead),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/nomad/jobspec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-nomad/nomad/helper"
 )
 
 func resourceJob() *schema.Resource {
@@ -36,7 +37,7 @@ func resourceJob() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: helper.NamespacedImporter(resourceJobRead),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -37,7 +37,7 @@ func resourceJob() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			StateContext: helper.NamespacedImporter(resourceJobRead),
+			StateContext: helper.NamespacedImporterContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/website/docs/r/csi_volume.html.markdown
+++ b/website/docs/r/csi_volume.html.markdown
@@ -139,8 +139,7 @@ configuration options.
 
 ## Importing CSI Volumes
 
-You can use the ID format `<volume ID>@<namespace>` to import CSI volumes from
-non-default namespaces.
+CSI volumes are imported using the pattern `<volume ID>@<namespace>` .
 
 ```console
 $ terraform import nomad_csi_volume.mysql mysql@my-namespace
@@ -154,9 +153,6 @@ Import successful!
 The resources that were imported are shown above. These resources are now in
 your Terraform state and will henceforth be managed by Terraform.
 ```
-
-The `@<namespace>` component my be omitted if the volume is registered in the
-`default` namespace.
 
 [tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts
 [tf_docs_prevent_destroy]: https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#prevent_destroy

--- a/website/docs/r/csi_volume.html.markdown
+++ b/website/docs/r/csi_volume.html.markdown
@@ -137,5 +137,26 @@ configuration options.
 - `create` `(string: "10m")` - Timeout when creating or updating a new CSI volume.
 - `delete` `(string: "10m")` - Timeout when deleting a CSI volume.
 
+## Importing CSI Volumes
+
+You can use the ID format `<volume ID>@<namespace>` to import CSI volumes from
+non-default namespaces.
+
+```console
+$ terraform import nomad_csi_volume.mysql mysql@my-namespace
+nomad_csi_volume.mysql: Importing from ID "mysql@my-namespace"...
+nomad_csi_volume.mysql: Import prepared!
+  Prepared nomad_csi_volume for import
+nomad_csi_volume.mysql: Refreshing state... [id=mysql@my-namespace]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+The `@<namespace>` component my be omitted if the volume is registered in the
+`default` namespace.
+
 [tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts
 [tf_docs_prevent_destroy]: https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#prevent_destroy

--- a/website/docs/r/csi_volume_registration.html.markdown
+++ b/website/docs/r/csi_volume_registration.html.markdown
@@ -130,4 +130,25 @@ can be referenced:
 - `create` `(string: "10m")` - Timeout when registering a new CSI volume.
 - `delete` `(string: "10m")` - Timeout when deregistering a CSI volume.
 
+## Importing CSI Volume Registrations
+
+You can use the ID format `<volume ID>@<namespace>` to import CSI volume
+registrations from non-default namespaces.
+
+```console
+$ terraform import nomad_csi_volume.mysql mysql@my-namespace
+nomad_csi_volume_registration.mysql: Importing from ID "mysql@my-namespace"...
+nomad_csi_volume_registration.mysql: Import prepared!
+  Prepared nomad_csi_volume_registration for import
+nomad_csi_volume_registration.mysql: Refreshing state... [id=mysql@my-namespace]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+The `@<namespace>` component my be omitted if the volume is registered in the
+`default` namespace.
+
 [tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts

--- a/website/docs/r/csi_volume_registration.html.markdown
+++ b/website/docs/r/csi_volume_registration.html.markdown
@@ -132,8 +132,8 @@ can be referenced:
 
 ## Importing CSI Volume Registrations
 
-You can use the ID format `<volume ID>@<namespace>` to import CSI volume
-registrations from non-default namespaces.
+CSI volume registrations are imported using the pattern
+`<volume ID>@<namespace>`.
 
 ```console
 $ terraform import nomad_csi_volume.mysql mysql@my-namespace
@@ -147,8 +147,5 @@ Import successful!
 The resources that were imported are shown above. These resources are now in
 your Terraform state and will henceforth be managed by Terraform.
 ```
-
-The `@<namespace>` component my be omitted if the volume is registered in the
-`default` namespace.
 
 [tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -302,8 +302,7 @@ options when [`detach`](#detach) is set to `false`:
 
 ## Importing Jobs
 
-You can use the ID format `<job ID>@<namespace>` to import jobs from
-non-default namespaces.
+Jobs are imported using the pattern `<job ID>@<namespace>`.
 
 ```console
 $ terraform import nomad_job.example example@my-namespace
@@ -317,9 +316,6 @@ Import successful!
 The resources that were imported are shown above. These resources are now in
 your Terraform state and will henceforth be managed by Terraform.
 ```
-
-The `@<namespace>` component my be omitted if the job is registered in the
-`default` namespace.
 
 [tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts
 [tf_docs_templatefile]: https://www.terraform.io/docs/configuration/functions/templatefile.html

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -300,6 +300,27 @@ options when [`detach`](#detach) is set to `false`:
 - `create` `(string: "5m")` - Timeout when registering a new job.
 - `update` `(string: "5m")` - Timeout when updating an existing job.
 
+## Importing Jobs
+
+You can use the ID format `<job ID>@<namespace>` to import jobs from
+non-default namespaces.
+
+```console
+$ terraform import nomad_job.example example@my-namespace
+nomad_job.example: Importing from ID "example@my-namespace"...
+nomad_job.example: Import prepared!
+  Prepared nomad_job for import
+nomad_job.example: Refreshing state... [id=example@my-namespace]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+The `@<namespace>` component my be omitted if the job is registered in the
+`default` namespace.
+
 [tf_docs_timeouts]: https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts
 [tf_docs_templatefile]: https://www.terraform.io/docs/configuration/functions/templatefile.html
 [tf_docs_string_template]: https://www.terraform.io/language/expressions/strings#string-templates


### PR DESCRIPTION
`nomad_job`, `nomad_csi_volume`, and `nomad_csi_volume_registration` do not have the namespace as part of their state ID. This makes it impossible to import them if they are registered in a non-default namespace since only the ID is provided to the import function.

This commit adds a new helper that imports using an ID with the format `<id>@<namespace>`. Since `@` is not a valid character for namespaces, the last `@` character (if found) represents the separator.

Implements the approach suggested in https://github.com/hashicorp/terraform-provider-nomad/pull/375#issuecomment-1686797489.