### PR TITLE
volume: add computed attribute `external_id`

### DIFF
--- a/nomad/resource_csi_volume.go
+++ b/nomad/resource_csi_volume.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"hash/crc32"
 	"log"
+	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -24,10 +26,7 @@ func resourceCSIVolume() *schema.Resource {
 		CreateContext: resourceCSIVolumeCreate,
 		UpdateContext: resourceCSIVolumeCreate,
 		DeleteContext: resourceCSIVolumeDelete,
-
-		// Once created, CSI volumes are automatically registered as a
-		// normal volume.
-		Read: resourceCSIVolumeRead,
+		Read:          resourceCSIVolumeRead,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -336,13 +335,77 @@ func resourceCSIVolume() *schema.Resource {
 					},
 				},
 			},
+			"external_id": {
+				Description: "The ID of the physical volume from the storage provider.",
+				Computed:    true,
+				Type:        schema.TypeString,
+			},
 		},
 	}
 }
 
-func resourceCSIVolumeRead(d *schema.ResourceData, meta any) error {
-	_, err := readCSIVolume(d, meta)
-	return err
+// resourceCSIVolumeRead is shared between nomad_csi_volume and
+// nomad_csi_volume_registration because once a volume is stored in Nomad it
+// is read from the same endpoint, regardless of how it was created.
+func resourceCSIVolumeRead(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(ProviderConfig)
+	client := providerConfig.client
+
+	id := d.Id()
+	opts := &api.QueryOptions{
+		Namespace: d.Get("namespace").(string),
+	}
+	if opts.Namespace == "" {
+		opts.Namespace = "default"
+	}
+	log.Printf("[DEBUG] reading information for CSI volume %q in namespace %q", id, opts.Namespace)
+	volume, _, err := client.CSIVolumes().Info(id, opts)
+	if err != nil {
+		// As of Nomad 0.4.1, the API client returns an error for 404
+		// rather than a nil result, so we must check this way.
+		if strings.Contains(err.Error(), "404") {
+			log.Printf("[DEBUG] CSI volume %q does not exist, so removing", id)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("error checking for CSI volume: %s", err)
+	}
+	log.Printf("[DEBUG] found CSI volume %q in namespace %q", volume.Name, volume.Namespace)
+
+	d.Set("name", volume.Name)
+	d.Set("namespace", volume.Namespace)
+	d.Set("volume_id", volume.ID)
+	d.Set("external_id", volume.ExternalID)
+
+	d.Set("capacity", int(volume.Capacity))
+	d.Set("capacity_min_bytes", volume.RequestedCapacityMin)
+	d.Set("capacity_max_bytes", volume.RequestedCapacityMax)
+	// only save capacity min/max in state if the user has set it/them
+	if cMin := d.Get("capacity_min").(string); cMin != "" {
+		d.Set("capacity_min", humanize.IBytes(uint64(volume.RequestedCapacityMin)))
+	}
+	if cMax := d.Get("capacity_max").(string); cMax != "" {
+		d.Set("capacity_max", humanize.IBytes(uint64(volume.RequestedCapacityMax)))
+	}
+
+	d.Set("controller_required", volume.ControllerRequired)
+	d.Set("controllers_expected", volume.ControllersExpected)
+	d.Set("controllers_healthy", volume.ControllersHealthy)
+	d.Set("controllers_healthy", volume.ControllersHealthy)
+	d.Set("plugin_id", volume.PluginID)
+	d.Set("plugin_provider", volume.Provider)
+	d.Set("plugin_provider_version", volume.ProviderVersion)
+	d.Set("nodes_healthy", volume.NodesHealthy)
+	d.Set("nodes_expected", volume.NodesExpected)
+	d.Set("schedulable", volume.Schedulable)
+	d.Set("capability", flattenCSIVolumeCapabilities(volume.RequestedCapabilities))
+	d.Set("topologies", flattenCSIVolumeTopologies(volume.Topologies))
+	d.Set("topology_request", flattenCSIVolumeTopologyRequests(volume.RequestedTopologies))
+	// The Nomad API redacts `mount_options` and `secrets`, so we don't update them
+	// with the response payload; they will remain as is.
+
+	return nil
 }
 
 func resourceCSIVolumeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
CSI volumes have an external ID regardless on how they were added to Nomad, so add a computed attribute `external_id` to `nomad_csi_volume`.

This makes the schema of `nomad_csi_volume` and
`nomad_csi_volume_registration` compatible so that the read method can be shared between then again.

Alternate (and arguably correct 😅) implementation of https://github.com/hashicorp/terraform-provider-nomad/pull/402