### PR TITLE
job: prevent partial update on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 * resource/nomad_acl_policy: fixed a bug where the namespace would be incorrectly calculated from a job identity ([#396](https://github.com/hashicorp/terraform-provider-nomad/pull/396))
 * resource/nomad_csi_volume_registration: fixed a bug that cause an import operation to not load all of the volume attributes ([#402](https://github.com/hashicorp/terraform-provider-nomad/pull/402))
 * resource/nomad_job: fixed a bug that could cause jobs to be registered in the incorrect namespace if the `NOMAD_NAMESPACE` environment variable is set ([#386](https://github.com/hashicorp/terraform-provider-nomad/pull/386))
+* resource/nomad_job: fixed a bug that caused state changes even in case of errors during apply ([#412](https://github.com/hashicorp/terraform-provider-nomad/pull/412))
 * resource/nomad_volume: fixed a bug that cause an import operation to not load all of the volume attributes ([#402](https://github.com/hashicorp/terraform-provider-nomad/pull/402))
 
 ## 2.0.0 (August 28th, 2023)

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -362,6 +362,7 @@ func resourceJobRegister(d *schema.ResourceData, meta interface{}) error {
 	timeout := d.Timeout(schema.TimeoutCreate)
 	if !d.IsNewResource() {
 		timeout = d.Timeout(schema.TimeoutUpdate)
+		d.Partial(true)
 	}
 
 	providerConfig := meta.(ProviderConfig)
@@ -413,6 +414,10 @@ func resourceJobRegister(d *schema.ResourceData, meta interface{}) error {
 	})
 	if err != nil {
 		return fmt.Errorf("error applying jobspec: %s", err)
+	}
+
+	if !d.IsNewResource() {
+		d.Partial(false)
 	}
 
 	log.Printf("[DEBUG] job '%s' registered in namespace '%s'", *job.ID, *job.Namespace)


### PR DESCRIPTION
The default behaviour of the Terraform SDK is to copy the plan result into state which could result in partial state updates, where Terraform state is updated, but the actual resource state is not, in case of an error during the apply.

This is normally not an issue because resources are expected to undo these changes on state refresh. Any partial update is reconciled with the actual resource state.

But due to #1, the `nomad_job` resource is not able to properly reconcile on refresh, causing the partial update to prevent further applies unless the configuration is also changed.

This commit uses the `d.Partial()` method to signal to Terraform that any state changes should be rolledback in case of an error.

Closes #385