### PR TITLE
deps: update `nomad/api` package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/nomad v1.7.2
-	github.com/hashicorp/nomad/api v0.0.0-20231213195942-64e3dca9274b
+	github.com/hashicorp/nomad/api v0.0.0-20231219145541-859606a54ade
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
 	github.com/hashicorp/vault v0.10.4
 	github.com/shoenig/test v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/nomad v1.7.2 h1:r6SMADcuR9mCw1Btobrghv5EceSKT/P63VJBwC/Q1zw=
 github.com/hashicorp/nomad v1.7.2/go.mod h1:x2DDZbesJHNHXMNps6lZkWUTFN9uQI9s38yEnB/3b7M=
-github.com/hashicorp/nomad/api v0.0.0-20231213195942-64e3dca9274b h1:R1UDhkwGltpSPY9bCBBxIMQd+NY9BkN0vFHnJo/8o8w=
-github.com/hashicorp/nomad/api v0.0.0-20231213195942-64e3dca9274b/go.mod h1:ijDwa6o1uG1jFSq6kERiX2PamKGpZzTmo0XOFNeFZgw=
+github.com/hashicorp/nomad/api v0.0.0-20231219145541-859606a54ade h1:tNZmy3PBf2zmkN62O/PqcVZUmaws+BMEiqjmU7qviUg=
+github.com/hashicorp/nomad/api v0.0.0-20231219145541-859606a54ade/go.mod h1:ijDwa6o1uG1jFSq6kERiX2PamKGpZzTmo0XOFNeFZgw=
 github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
 github.com/hashicorp/terraform-exec v0.18.1 h1:LAbfDvNQU1l0NOQlTuudjczVhHj061fNX5H8XZxHlH4=


### PR DESCRIPTION
Pin `nomad/api` to https://github.com/hashicorp/nomad/commit/859606a54ade3fde43c2d89ed20a5e621ef2a53b so `service.cluster` is parsed properly.