### PR TITLE
ci: update Nomad version used in tests

### DIFF
--- a/scripts/getnomad.sh
+++ b/scripts/getnomad.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-NOMAD_VERSION='1.7.2'
+NOMAD_VERSION='1.7.5'
 if [[ -n "$NOMAD_LICENSE" || -n "$NOMAD_LICENSE_PATH" ]]; then
     NOMAD_VERSION=${NOMAD_VERSION}+ent
 fi


### PR DESCRIPTION
Fix CI by updating the Nomad version installed.

https://github.com/hashicorp/terraform-provider-nomad/pull/429 added support to a feature that is only available on Nomad 1.7.3+. I'm not sure why CI didn't run in that PR 🤷 