### PR TITLE
test: fix `TestResourceVariable_namespaceChange`

### DIFF
--- a/nomad/resource_variable_test.go
+++ b/nomad/resource_variable_test.go
@@ -98,7 +98,7 @@ resource nomad_namespace "nomad_var_test" {
   name = "%s"
 }
 %s
-`, namespace, testResourceVariable_initialConfig(namespace, path))
+`, namespace, testResourceVariable_initialConfig("${nomad_namespace.nomad_var_test.name}", path))
 }
 
 func testResourceVariable_initialCheck(namespace, path string) resource.TestCheckFunc {


### PR DESCRIPTION
Establish implicit dependency between the variable and the new namespace so they are destroyed in the right order.

Closes #440