### PR TITLE
acl_auth_method: fix token name format default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ IMPROVEMENTS:
 * provider: update Go to 1.22.1 ([#439](https://github.com/hashicorp/terraform-provider-nomad/pull/439))
 * resource/acl_auth_method: add support for `oidc_disable_userinfo` ([#429](https://github.com/hashicorp/terraform-provider-nomad/pull/429))
 
+BUG FIXES:
+* resource/nomad_acl_auth_method: fixed a bug that caused an unexpected plan difference when the `token_name_format` argument was not defined ([#442](https://github.com/hashicorp/terraform-provider-nomad/pull/442))
+
 ## 2.1.1 (January 30, 2024)
 
 NOTES:

--- a/nomad/resource_acl_auth_method.go
+++ b/nomad/resource_acl_auth_method.go
@@ -58,6 +58,7 @@ func resourceACLAuthMethod() *schema.Resource {
 				Description: "Defines the token format for the authenticated users. This can be lightly templated using HIL '${foo}' syntax.",
 				Optional:    true,
 				Type:        schema.TypeString,
+				Default:     "${auth_method_type}-${auth_method_name}",
 			},
 			"default": {
 				Description: "Defines whether this ACL Auth Method is to be set as default.",

--- a/website/docs/r/acl_auth_method.html.markdown
+++ b/website/docs/r/acl_auth_method.html.markdown
@@ -55,9 +55,9 @@ The following arguments are supported:
 - `max_token_ttl` `(string: <required>)` - Defines the maximum life of a token
   created by this method and is specified as a time duration such as "15h".
 
-- `token_name_format` `(string: <optional>)` - Defines the token name format for the
-  generated tokens This can be lightly templated using HIL '${foo}' syntax.
-  Defaults to `${auth_method_type}-${auth_method_name}`.
+- `token_name_format` `(string: "${auth_method_type}-${auth_method_name}")` -
+  Defines the token name format for the generated tokens This can be lightly
+  templated using HIL '${foo}' syntax.
 
 - `default` `(bool: false)` - Defines whether this ACL Auth Method is to be set
   as default.


### PR DESCRIPTION
Set the token name default value used by Nomad to avoid unnecessary plan changes when the attribute is not defined.

Reported in https://github.com/hashicorp/terraform-provider-nomad/pull/403#issuecomment-1960136907