### PR TITLE
ci: use latest version of Nomad's hostpath jobfile.

### DIFF
--- a/scripts/start-nomad.sh
+++ b/scripts/start-nomad.sh
@@ -56,7 +56,7 @@ EOF
     done
 
     # Run hostpath CSI plugin and wait for it to be healthy.
-    nomad job run https://raw.githubusercontent.com/hashicorp/nomad/v1.3.1/demo/csi/hostpath/plugin.nomad 1>&2
+    nomad job run https://raw.githubusercontent.com/hashicorp/nomad/v1.8.0/demo/csi/hostpath/plugin.nomad 1>&2
     echo "Waiting for hostpath CSI plugin to become healthy" 1>&2
     retries=30
     while [ $retries -ge 0 ]; do


### PR DESCRIPTION
Fixes CI errors such as the one seen here: https://github.com/hashicorp/terraform-provider-nomad/actions/runs/9535034665/job/26299008859