### PR TITLE
namespaces: handle quota spec disassociation and non-terminal allocations

### DIFF
--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -1498,7 +1498,8 @@ func testResourceJob_volumesCheck(s *terraform.State) error {
 			"Volume": "data",
             "Destination": "/var/lib/data",
             "ReadOnly": true,
-			"PropagationMode": "private"
+			"PropagationMode": "private",
+			"SELinuxLabel": ""
 		}
 	]`), &expVolumeMounts)
 	if diff := cmp.Diff(expVolumeMounts, task.VolumeMounts); diff != "" {
@@ -3414,7 +3415,7 @@ var testResourceJobUIBlock = `
 resource "nomad_job" "ui" {
 	jobspec = <<EOT
 job "foo-schedule" {
-  UI {
+  ui {
     description = "A job that includes a UI block"
   }
 

--- a/nomad/resource_namespace.go
+++ b/nomad/resource_namespace.go
@@ -181,6 +181,9 @@ func resourceNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
 			if d.Get("quota") != "" {
 				d.Set("quota", "")
 				err = resourceNamespaceWrite(d, meta)
+				if err != nil {
+					return err
+				}
 			}
 			_, err = client.Namespaces().Delete(name, nil)
 		}
@@ -188,7 +191,7 @@ func resourceNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
 		if err == nil {
 			break
 		} else if retries < 10 {
-			if strings.Contains(err.Error(), "has non-terminal jobs") {
+			if strings.Contains(err.Error(), "has non-terminal jobs") || strings.Contains(err.Error(), "has non-terminal allocations") {
 				log.Printf("[WARN] could not delete namespace %q because of non-terminal jobs, will pause and retry", name)
 				time.Sleep(5 * time.Second)
 				retries++

--- a/nomad/resource_namespace.go
+++ b/nomad/resource_namespace.go
@@ -177,6 +177,11 @@ func resourceNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
 			d.Set("quota", "")
 			err = resourceNamespaceWrite(d, meta)
 		} else {
+			// make sure there are no quota specs associated with that namespace
+			if d.Get("quota") != "" {
+				d.Set("quota", "")
+				err = resourceNamespaceWrite(d, meta)
+			}
 			_, err = client.Namespaces().Delete(name, nil)
 		}
 

--- a/nomad/resource_namespace_test.go
+++ b/nomad/resource_namespace_test.go
@@ -227,10 +227,24 @@ resource "nomad_namespace" "test" {
 
 func testResourceNamespace_configWithQuota(name, quota string) string {
 	return fmt.Sprintf(`
+resource "nomad_quota_specification" "test_quota" {
+  name        = "%[2]s"
+  description = "A Terraform acctest quota spec"
+
+  limits {
+    region = "global"
+
+    region_limit {
+      cpu       = 2400
+      memory_mb = 1200
+    }
+  }
+}
+
 resource "nomad_namespace" "test" {
-  name = "%s"
+  name = "%[1]s"
   description = "A Terraform acctest namespace"
-  quota = "%s"
+  quota = "%[2]s"
 
   meta = {
     key = "value",

--- a/nomad/resource_namespace_test.go
+++ b/nomad/resource_namespace_test.go
@@ -322,6 +322,28 @@ func testResourceNamespace_delete(t *testing.T, name string) func() {
 	}
 }
 
+func testResourceNamespaceWithQuota_delete() resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		namespaceWithQuotaSpec := api.Namespace{
+			Name:        api.DefaultNamespace,
+			Description: "Default shared namespace",
+			Quota:       "quota1",
+		}
+		client := testProvider.Meta().(ProviderConfig).client
+		_, err := client.Namespaces().Register(&namespaceWithQuotaSpec, nil)
+		if err != nil {
+			return fmt.Errorf("failed to register namespace %q.", namespaceWithQuotaSpec.Name)
+		}
+
+		_, err = client.Namespaces().Delete(namespaceWithQuotaSpec.Name, nil)
+		if err != nil {
+			return fmt.Errorf("failed to delete namespace %q: %s", namespaceWithQuotaSpec.Name, err.Error())
+		}
+
+		return nil
+	}
+}
+
 func testResourceNamespace_updateConfig(name string) string {
 	return fmt.Sprintf(`
 resource "nomad_namespace" "test" {

--- a/nomad/resource_namespace_test.go
+++ b/nomad/resource_namespace_test.go
@@ -251,7 +251,9 @@ resource "nomad_namespace" "test" {
   name = "%[1]s"
   description = "A Terraform acctest namespace"
   quota = "%[2]s"
-  depends_on = "test_quota"
+  depends_on = [
+    nomad_quota_specification.test_quota
+  ]
 
   meta = {
     key = "value",

--- a/nomad/resource_namespace_test.go
+++ b/nomad/resource_namespace_test.go
@@ -331,7 +331,7 @@ func testResourceNamespaceWithQuota_check(name, quota string) resource.TestCheck
 		client := testProvider.Meta().(ProviderConfig).client
 		namespace, _, err := client.Namespaces().Info(name, nil)
 		if err != nil {
-			return fmt.Errorf("error reading back namespace %q: %s", name, err)
+			return fmt.Errorf("error reading back namespace %q: %w", name, err)
 		}
 
 		if namespace.Quota != quota {

--- a/nomad/resource_quota_specification.go
+++ b/nomad/resource_quota_specification.go
@@ -122,8 +122,8 @@ func resourceQuotaSpecificationDelete(d *schema.ResourceData, meta interface{}) 
 			_, err := client.Namespaces().Register(ns, nil)
 			if err != nil {
 				return fmt.Errorf(
-					"error disassociating quota spec %q with namespace %s: %s",
-					name, ns.Name, err.Error(),
+					"error disassociating quota spec %q with namespace %s: %w",
+					name, ns.Name, err,
 				)
 			}
 		}

--- a/scripts/getnomad.sh
+++ b/scripts/getnomad.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-NOMAD_VERSION='1.7.5'
+NOMAD_VERSION='1.8.2'
 if [[ -n "$NOMAD_LICENSE" || -n "$NOMAD_LICENSE_PATH" ]]; then
     NOMAD_VERSION=${NOMAD_VERSION}+ent
 fi


### PR DESCRIPTION
Nomad 1.8.2 will [no longer allow](https://github.com/hashicorp/nomad/pull/23499) for deleting of quota specs if they are associated with a namespace. Namespace deletion will now also detect non-terminal allocations, so we have to support retries when deleting these. 

Fixes https://github.com/hashicorp/nomad/issues/23672
Internal ref: https://hashicorp.atlassian.net/browse/NET-10579

_note to reviewers:_ this PR also bumps the version of Nomad used for unit tests to 1.8.2. I will make a follow-up PR that installs nomad with hc-install so that we can assure we're always running tests against latest stable. 