### PR TITLE
testing: reduce skipped checks for non-enterprise builds

### DIFF
--- a/nomad/data_source_namespaces_test.go
+++ b/nomad/data_source_namespaces_test.go
@@ -15,7 +15,7 @@ import (
 func TestDataSourceNamespaces(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceNamespaces_config,

--- a/nomad/datasource_nomad_job_test.go
+++ b/nomad/datasource_nomad_job_test.go
@@ -69,7 +69,7 @@ func TestAccDataSourceNomadJob_Namespaced(t *testing.T) {
 	ns := "jobds-test-namespace"
 	job := "testjobds-namespace"
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testCheckEnt(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testProviders,
 		CheckDestroy: testResourceJob_forceDestroyWithPurge(job, ns),
 		Steps: []resource.TestStep{

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -60,7 +60,7 @@ func TestResourceJob_service(t *testing.T) {
 func TestResourceJob_namespace(t *testing.T) {
 	r.Test(t, r.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []r.TestStep{
 			{
 				Config: testResourceJob_initialConfigNamespace,
@@ -248,6 +248,7 @@ func TestResourceJob_schedule(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testCheckMinVersion(t, "1.8.0-rc.1")
+			testCheckEnt(t)
 		},
 		Steps: []r.TestStep{
 			{
@@ -491,7 +492,7 @@ func TestResourceJob_rename(t *testing.T) {
 func TestResourceJob_change_namespace(t *testing.T) {
 	r.Test(t, r.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t); testCheckEnt(t) },
+		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []r.TestStep{
 			{
 				Config: testResourceJob_initialConfigNamespace,

--- a/nomad/resource_namespace_test.go
+++ b/nomad/resource_namespace_test.go
@@ -137,7 +137,7 @@ func TestResourceNamespace_deleteNSWithQuota(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testCheckEnt(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceNamespace_configWithQuota(nsName, quotaName),


### PR DESCRIPTION
Namespaces were moved from Enterprise to CE some time ago, but it appears that some of the tests for the provider never had their ENT-only gate removed so they're not being run on CE. One test for scheduler configuration was missing an ENT-only gate as well.

Additionally, missing `t.Helper()` flags were causing these skips to be reported as if they were version number check failures, which was confusing. This changeset fixes that and simplifies the test helper for version checks so the helper function that gets the version from the node returns a value rather than taking a callback, and uses the `Core` method on the checked version to allow easier development against new features on Nomad's main branch.