### PR TITLE
add context argument to resource.nomad_csi_volume

### DIFF
--- a/nomad/resource_csi_volume.go
+++ b/nomad/resource_csi_volume.go
@@ -340,6 +340,11 @@ func resourceCSIVolume() *schema.Resource {
 				Computed:    true,
 				Type:        schema.TypeString,
 			},
+			"context": {
+				Description: "The volume context provided by the storage provider",
+				Computed:    true,
+				Type:        schema.TypeMap,
+			},
 		},
 	}
 }
@@ -402,6 +407,7 @@ func resourceCSIVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("capability", flattenCSIVolumeCapabilities(volume.RequestedCapabilities))
 	d.Set("topologies", flattenCSIVolumeTopologies(volume.Topologies))
 	d.Set("topology_request", flattenCSIVolumeTopologyRequests(volume.RequestedTopologies))
+	d.Set("context", volume.Context)
 	// The Nomad API redacts `mount_options` and `secrets`, so we don't update them
 	// with the response payload; they will remain as is.
 
@@ -451,6 +457,7 @@ func resourceCSIVolumeCreate(ctx context.Context, d *schema.ResourceData, meta i
 		RequestedTopologies:   topologyRequest,
 		Secrets:               helper.ToMapStringString(d.Get("secrets")),
 		Parameters:            helper.ToMapStringString(d.Get("parameters")),
+		Context:               helper.ToMapStringString(d.Get("context")),
 	}
 
 	// Unpack the mount_options if we have any and configure the volume struct.

--- a/website/docs/r/csi_volume.html.markdown
+++ b/website/docs/r/csi_volume.html.markdown
@@ -128,6 +128,7 @@ can be referenced:
 - `nodes_expected`: `(integer)`
 - `schedulable`: `(boolean)`
 - `topologies`: `(List of topologies)`
+- `context`: `(map[string]string)`
 
 ### Timeouts
 


### PR DESCRIPTION
The `context` output is missing from `resource.nomad_csi_volume`. This prevents successfully migrating from the deprecated `resource.nomad_external_volume`. Add it as a computed value that we get from the plugins.

Fixes: https://github.com/hashicorp/terraform-provider-nomad/issues/494
Fixes: https://github.com/hashicorp/terraform-provider-nomad/issues/417
Ref: https://hashicorp.atlassian.net/browse/NET-11851

---

Tested using the most recent available Docker release of [democratic-csi](https://github.com/democratic-csi/democratic-csi) (v1.9.3, not sure why the version shows as 1.9.0 below).

```
$ nomad plugin status org.democratic-csi.nfs
ID                   = org.democratic-csi.nfs
Provider             = org.democratic-csi.nfs
Version              = 1.9.0
Controllers Healthy  = 1
Controllers Expected = 1
Nodes Healthy        = 1
Nodes Expected       = 1

Allocations
No allocations placed
```

<details><summary>terraform configuration</summary>

```hcl
provider "nomad" {
  address = "https://nomad3.local:4646"
  region  = "global"
}

data "nomad_plugin" "nfs" {
  plugin_id        = "org.democratic-csi.nfs"
  wait_for_healthy = true
}

resource "nomad_csi_volume" "example" {

  depends_on = [data.nomad_plugin.nfs]

  lifecycle {
    prevent_destroy = true
  }

  plugin_id = "org.democratic-csi.nfs"
  volume_id = "example1"
  name      = "example-volume"
  capacity_max = "500MiB"
  capacity_min = "200MiB"

  capability {
    access_mode     = "single-node-writer"
    attachment_mode = "file-system"
  }

}

output "message" {
  value = <<EOM

Volume: ${resource.nomad_csi_volume.example.id}

Computed properties:

  context:
%{for k, v in resource.nomad_csi_volume.example.context~}
    - ${k} => ${v}
%{endfor~}

  controller_required: ${resource.nomad_csi_volume.example.controller_required}
  controllers_expected: ${resource.nomad_csi_volume.example.controllers_expected}
  controllers_healthy: ${resource.nomad_csi_volume.example.controllers_healthy}
  nodes_expected: ${resource.nomad_csi_volume.example.nodes_expected}
  nodes_healthy: ${resource.nomad_csi_volume.example.nodes_healthy}
  plugin_provider: ${resource.nomad_csi_volume.example.plugin_provider}
  plugin_provider_version: ${resource.nomad_csi_volume.example.plugin_provider_version}
  schedulable: ${resource.nomad_csi_volume.example.schedulable}

EOM

}
```

</details>

<details><summary>terraform apply</summary>

```
$ terraform apply -auto-approve

Terraform will perform the following actions:

  # nomad_csi_volume.example will be created
  + resource "nomad_csi_volume" "example" {
      + capacity                = (known after apply)
      + capacity_max            = "500 MiB"
      + capacity_max_bytes      = (known after apply)
      + capacity_min            = "200 MiB"
      + capacity_min_bytes      = (known after apply)
      + context                 = (known after apply)
      + controller_required     = (known after apply)
      + controllers_expected    = (known after apply)
      + controllers_healthy     = (known after apply)
      + external_id             = (known after apply)
      + id                      = (known after apply)
      + name                    = "example-volume"
      + namespace               = "default"
      + nodes_expected          = (known after apply)
      + nodes_healthy           = (known after apply)
      + plugin_id               = "org.democratic-csi.nfs"
      + plugin_provider         = (known after apply)
      + plugin_provider_version = (known after apply)
      + schedulable             = (known after apply)
      + topologies              = (known after apply)
      + volume_id               = "example1"

      + capability {
          + access_mode     = "single-node-writer"
          + attachment_mode = "file-system"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  ~ message = <<-EOT
        Volume: example1

        Computed properties:

          context:
            - node_attach_driver => nfs
            - provisioner_driver => nfs-client
            - server => 192.168.1.170
            - share => /srv/nfs_data/v/example-volume

          controller_required: true
          controllers_expected: 1
          controllers_healthy: 1
          nodes_expected: 1
          nodes_healthy: 1
          plugin_provider: org.democratic-csi.nfs
          plugin_provider_version: 1.9.0
          schedulable: true
    EOT -> (known after apply)
nomad_csi_volume.example: Creating...
nomad_csi_volume.example: Creation complete after 0s [id=example1]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

message = <<EOT

Volume: example1

Computed properties:

  context:
    - node_attach_driver => nfs
    - provisioner_driver => nfs-client
    - server => 192.168.1.170
    - share => /srv/nfs_data/v/example-volume

  controller_required: true
  controllers_expected: 1
  controllers_healthy: 1
  nodes_expected: 1
  nodes_healthy: 1
  plugin_provider: org.democratic-csi.nfs
  plugin_provider_version: 1.9.0
  schedulable: true


EOT

```

</details>

<details><summary>terraform plan to verify no changes</summary>

```
$ terraform plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/nomad in /home/tim/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause
│ the state to become incompatible with published releases.
╵
data.nomad_plugin.nfs: Reading...
data.nomad_plugin.nfs: Read complete after 0s [id=org.democratic-csi.nfs]
nomad_csi_volume.example: Refreshing state... [id=example1]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no
changes are needed.
```

</details>

Results from Nomad API:

```
$ nomad volume status
Container Storage Interface
ID        Name            Namespace  Plugin ID               Schedulable  Access Mode
example1  example-volume  default    org.democratic-csi.nfs  true         <none>

$ nomad volume status example1
ID                   = example1
Name                 = example-volume
Namespace            = default
External ID          = example-volume
Plugin ID            = org.democratic-csi.nfs
Provider             = org.democratic-csi.nfs
Version              = 1.9.0
Capacity             = 0 B
Schedulable          = true
Controllers Healthy  = 1
Controllers Expected = 1
Nodes Healthy        = 1
Nodes Expected       = 1
Access Mode          = <none>
Attachment Mode      = <none>
Mount Options        = <none>

Allocations
No allocations placed

$ nomad operator api "/v1/volume/csi/example1" | jq .Context
{
  "provisioner_driver": "nfs-client",
  "node_attach_driver": "nfs",
  "server": "192.168.1.170",
  "share": "/srv/nfs_data/v/example-volume"
}
```
