### PR TITLE
docs: clarify workload-associated policy parameters

### DIFF
--- a/website/docs/r/acl_policy.html.markdown
+++ b/website/docs/r/acl_policy.html.markdown
@@ -45,20 +45,19 @@ The following arguments are supported:
 - `rules_hcl` `(string: <required>)` - The contents of the policy to register,
    as HCL or JSON.
 - `description` `(string: "")` - A description of the policy.
-- `job_acl`: `(`[`JobACL`](#jobacl-1)`: <optional>)` - Options for assigning the ACL rules to a job, group, or task.
+- `job_acl`: `(`[`JobACL`](#jobacl-1)`: <optional>)` - Options for assigning the
+  ACL rules to a job, group, or task.
 
 ### JobACL
 
-The `job_acl` block is used to associate the ACL policy with a given namespace,
-job, group, or task. Refer to [Workload Associated ACL Policies][nomad_docs_wi]
-for more information. The following arguments are supported.
+The `job_acl` block is used to associate the ACL policy with a given job, group,
+or task. Refer to [Workload Associated ACL Policies][nomad_docs_wi] for more
+information. The following arguments are supported.
 
-- `namespace` `(string: "default")` - The namespace to attach the policy.
-  Required if `job_id` is set.
-- `job_id` `(string: <optional>` - The job to attach the policy. Required if
-  `group` is set.
-- `group` `(string: <optional>` - The group to attach the policy. Required if
-  `task` is set.
-- `task` `(string: <optional>` - The task to attach the policy.
+- `namespace` `(string: "default")` - Attach the policy to the job in this namespace.
+- `job_id` `(string)` - Attach the policy to this job. Required.
+- `group` `(string: <optional>` - Attach the policy to this group in the
+  job. Required if `task` is set.
+- `task` `(string: <optional>` - Attach the policy to this task in the job.
 
 [nomad_docs_wi]: https://www.nomadproject.io/docs/concepts/workload-identity#workload-associated-acl-policies


### PR DESCRIPTION
Workload-associated ACL policies can only be set on a specific job within a namespace, not the namespace as a whole. Clarify the documentation of the provider.

Fixes: https://github.com/hashicorp/terraform-provider-nomad/issues/500
Ref: https://github.com/hashicorp/nomad/pull/24882
Ref: https://hashicorp.atlassian.net/browse/NET-11994