### PR TITLE
nomad_acl_auth_method: add verbose_logging option

### DIFF
--- a/nomad/resource_acl_auth_method.go
+++ b/nomad/resource_acl_auth_method.go
@@ -224,6 +224,12 @@ func resourceACLAuthMethodConfig() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 			},
+			"verbose_logging": {
+				Description: "Enables verbose logging",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+			},
 		},
 	}
 }
@@ -700,6 +706,8 @@ func generateNomadACLAuthMethodConfig(intf interface{}) (*api.ACLAuthMethodConfi
 				return nil, err
 			}
 			authMethodConfig.ListClaimMappings = unpacked
+		case "verbose_logging":
+			authMethodConfig.VerboseLogging = v.(bool)
 		}
 	}
 
@@ -730,6 +738,7 @@ func flattenACLAuthMethodConfig(cfg *api.ACLAuthMethodConfig) []any {
 		"clock_skew_leeway":       cfg.ClockSkewLeeway.String(),
 		"claim_mappings":          packStringMap(cfg.ClaimMappings),
 		"list_claim_mappings":     packStringMap(cfg.ListClaimMappings),
+		"verbose_logging":         cfg.VerboseLogging,
 	}
 	if cfg.OIDCClientAssertion != nil {
 		cAss := map[string]any{

--- a/nomad/resource_acl_auth_method.go
+++ b/nomad/resource_acl_auth_method.go
@@ -225,7 +225,7 @@ func resourceACLAuthMethodConfig() *schema.Resource {
 				Optional:    true,
 			},
 			"verbose_logging": {
-				Description: "Enables verbose logging",
+				Description: "Enable OIDC verbose logging on the Nomad server.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,

--- a/nomad/resource_acl_auth_method_test.go
+++ b/nomad/resource_acl_auth_method_test.go
@@ -70,6 +70,7 @@ resource "nomad_acl_auth_method" "test" {
     list_claim_mappings = {
       "http://nomad.internal/roles": "roles"
     }
+    verbose_logging = true
   }
 }
 
@@ -153,6 +154,7 @@ func testResourceACLAuthMethodCheck(name, uiCallback, defaultVal string) resourc
 			"config.0.claim_mappings.http://nomad.internal/name":       "name",
 			"config.0.list_claim_mappings.%":                           "1",
 			"config.0.list_claim_mappings.http://nomad.internal/roles": "roles",
+			"config.0.verbose_logging":                                 "true",
 		}
 
 		for testKey, testValue := range configExpectedEntries {
@@ -218,6 +220,9 @@ func testResourceACLAuthMethodCheck(name, uiCallback, defaultVal string) resourc
 		if !reflect.DeepEqual(authMethod.Config.ListClaimMappings, expectedListClaimMappings) {
 			return fmt.Errorf(`expected list claim mappings to be %q, is %q in API`,
 				expectedListClaimMappings, authMethod.Config.ListClaimMappings)
+		}
+		if !authMethod.Config.VerboseLogging {
+			return fmt.Errorf("expected VerboseLogging to be true, is %v in API", authMethod.Config.VerboseLogging)
 		}
 
 		return nil

--- a/website/docs/r/acl_auth_method.html.markdown
+++ b/website/docs/r/acl_auth_method.html.markdown
@@ -181,6 +181,11 @@ The following arguments are supported:
   - `list_claim_mappings`: `(map[string]string: <optional>)` - Mappings of list
     claims (key) that will be copied to a metadata field (value).
 
+  - `verbose_logging` `(bool: false)` - When set to `true`, Nomad will log token
+    claims, information related to binding-rule and role/policy evaluations,
+    and client assertion JWTs, if applicable. Not recommended in production,
+    since sensitive information may be present.
+
 [private key jwt]: https://oauth.net/private-key-jwt/
 [concepts-assertions]: /nomad/docs/concepts/acl/auth-methods/oidc#client-assertions
 [x5t]: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.7


### PR DESCRIPTION
Retrying #519 (sorry @nickwales for mistakenly closing it)

> This updates the auth method with the verbose_logging option that was added in 1.9.6.