### PR TITLE
run ent tests on ent clusters

### DIFF
--- a/nomad/provider_test.go
+++ b/nomad/provider_test.go
@@ -110,7 +110,6 @@ func testGetVersion(t *testing.T) *version.Version {
 		if version, err := version.NewVersion(nodes[0].Version); err != nil {
 			t.Skip("could not parse node version: ", err)
 		} else {
-			version = version.Core()
 			return version
 		}
 	} else {


### PR DESCRIPTION
Ent feature tests have been getting skipped. At first I thought it was due to CI not downloading an ent binary, but no it turns out that this one line is stripping the `+ent` metadata from the version.

I don't know why `.Core()` was put here initially, but it smells like it might have been vestigial after some reworking in 0cab885b832dd9ddd43594d953fd3605cabe6904 -- one caller calls `.Core()` on the _result_ of this `testGetVersion()` func to compare against min version.

The tests do still pass (on my laptop) when run without an ent binary, too.