### PR TITLE
ci: enable tests to pull requests

### DIFF
--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -1,7 +1,8 @@
 name: Check Copywrite Headers
 
 on:
-  push: {}
+  push:
+  pull_request:
 
 jobs:
   copywrite:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
I noticed when investigated https://github.com/hashicorp/terraform-provider-nomad/pull/542#pullrequestreview-3075640813 that PR validation is not enabled at all in here.

You can see from my fork https://github.com/olljanat/terraform-provider-nomad/pull/1 that merging this change and doing PR close + reopen triggered tests.