### PR TITLE
DHV: add namespace handling to import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ IMPROVEMENTS:
 * resource/nomad_namespace: add `enabled_network_modes` and `disabled_network_modes` attributes ([#542](https://github.com/hashicorp/terraform-provider-nomad/pull/542))
 * provider: add `auth_jwt` configuration option to use a jwt to perform authentication against an auth method ([#536](https://github.com/hashicorp/terraform-provider-nomad/pull/536))
 
+BUGS:
+* resource/nomad_dynamic_host_volume: Fixed a bug where volumes in the non-default namespace could not be imported. ([#554](https://github.com/hashicorp/terraform-provider-nomad/pull/554))
+* resource/nomad_dynamic_host_volume_registration: Fixed a bug where volumes in the non-default namespace could not be imported. ([#554](https://github.com/hashicorp/terraform-provider-nomad/pull/554))
+
 ## 2.5.0 (April 16, 2025)
 
 BREAKING CHANGES:

--- a/nomad/resource_dynamic_host_volume.go
+++ b/nomad/resource_dynamic_host_volume.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-nomad/nomad/helper"
 )
 
 func resourceDynamicHostVolume() *schema.Resource {
@@ -23,7 +24,7 @@ func resourceDynamicHostVolume() *schema.Resource {
 		Exists: resourceDynamicHostVolumeExists,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: helper.NamespacedImporterContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -226,6 +227,10 @@ func resourceDynamicHostVolumeWrite(d *schema.ResourceData, meta any) error {
 		return fmt.Errorf("error upserting node pool %q: %w", req.Volume.Name, err)
 	}
 	log.Printf("[DEBUG] Upserted dynamic host volume %q", resp.Volume.ID)
+
+	// note: this should be ID@namespace but by the time we realized that we'd
+	// already shipped it and there'll be backwards compatibility concerns with
+	// existing state
 	d.SetId(resp.Volume.ID)
 	d.Set("namespace", resp.Volume.Namespace)
 

--- a/nomad/resource_dynamic_host_volume_registration.go
+++ b/nomad/resource_dynamic_host_volume_registration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-nomad/nomad/helper"
 )
 
 func resourceDynamicHostVolumeRegistration() *schema.Resource {
@@ -22,7 +23,7 @@ func resourceDynamicHostVolumeRegistration() *schema.Resource {
 		Exists: resourceDynamicHostVolumeExists,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: helper.NamespacedImporterContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nomad/resource_dynamic_host_volume_registration_test.go
+++ b/nomad/resource_dynamic_host_volume_registration_test.go
@@ -32,6 +32,11 @@ func TestResourceDynamicHostVolumeRegistration_import(t *testing.T) {
 				ResourceName:      testResourceNameDynamicHostVolumeRegister,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					id, err := testResourceDynamicHostVolume_getStateID(state,
+						"nomad_dynamic_host_volume_registration.test")
+					return id, err
+				},
 			},
 		},
 		CheckDestroy: testResourceDynamicHostVolume_checkDestroy(

--- a/nomad/resource_dynamic_host_volume_test.go
+++ b/nomad/resource_dynamic_host_volume_test.go
@@ -35,6 +35,11 @@ func TestResourceDynamicHostVolume_import(t *testing.T) {
 				ResourceName:      testResourceNameDynamicHostVolume,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					id, err := testResourceDynamicHostVolume_getStateID(state,
+						"nomad_dynamic_host_volume.test")
+					return id, err
+				},
 			},
 		},
 		CheckDestroy: testResourceDynamicHostVolume_checkDestroy(
@@ -216,6 +221,21 @@ func testResourceDynamicHostVolume_update_check(resourceName, name string) resou
 
 		return nil
 	}
+}
+
+func testResourceDynamicHostVolume_getStateID(s *terraform.State, resourceName string) (string, error) {
+	resourceState := s.Modules[0].Resources[resourceName]
+	if resourceState == nil {
+		return "", errors.New("resource not found in state")
+	}
+
+	instanceState := resourceState.Primary
+	if instanceState == nil {
+		return "", errors.New("resource has no primary instance")
+	}
+	ns := instanceState.Attributes["namespace"]
+
+	return instanceState.ID + "@" + ns, nil
 }
 
 func testResourceDynamicHostVolume_getID(s *terraform.State, resourceName string) (string, error) {

--- a/website/docs/r/dynamic_host_volume.html.markdown
+++ b/website/docs/r/dynamic_host_volume.html.markdown
@@ -123,6 +123,23 @@ Creates and registers a dynamic host volume in Nomad.
   [`prevent_destroy`][tf_docs_prevent_destroy] directive to avoid accidental
   deletions.
 
+## Importing Dynamic Host Volumes
+
+Dynamic host volumes are imported using the pattern `<volume ID>@<namespace>` .
+
+```console
+$ terraform import nomad_dynamic_host_volume.mysql mysql@my-namespace
+nomad_dynamic_host_volume.mysql: Importing from ID "mysql@my-namespace"...
+nomad_dynamic_host_volume.mysql: Import prepared!
+  Prepared nomad_dynamic_host_volume for import
+nomad_dynamic_host_volume.mysql: Refreshing state... [id=mysql@my-namespace]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
 
 
 [tf_docs_prevent_destroy]: https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#prevent_destroy

--- a/website/docs/r/dynamic_host_volume_registration.html.markdown
+++ b/website/docs/r/dynamic_host_volume_registration.html.markdown
@@ -47,6 +47,23 @@ The following arguments are supported:
   passed directly to the plugin to configure the volume. The details of these
   parameters are specific to the plugin.
 
+## Importing Dynamic Host Volumes
+
+Dynamic host volumes are imported using the pattern `<volume ID>@<namespace>` .
+
+```console
+$ terraform import nomad_dynamic_host_volume_registration.mysql mysql@my-namespace
+nomad_dynamic_host_volume_registration.mysql: Importing from ID "mysql@my-namespace"...
+nomad_dynamic_host_volume_registration.mysql: Import prepared!
+  Prepared nomad_dynamic_host_volume_registration for import
+nomad_dynamic_host_volume_registration.mysql: Refreshing state... [id=mysql@my-namespace]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
 
 [`access_mode`]: /nomad/docs/other-specifications/volume/capability#access_mode
 [`attachment_mode`]: /nomad/docs/other-specifications/volume/capability#attachment_mode


### PR DESCRIPTION
When importing a dynamic host volume resource, the provider was missing the resource importer helper we use to pass in IDs like `$uuid@$namespace`. Add this to the importer and the docs.

Fixes: https://github.com/hashicorp/terraform-provider-nomad/issues/550

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

