### PR TITLE
deps: update Nomad Go API package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/nomad v1.10.5
-	github.com/hashicorp/nomad/api v0.0.0-20250410143434-48f304d0cab3
+	github.com/hashicorp/nomad/api v0.0.0-20251008130118-ee88f65316c3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/shoenig/test v1.12.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/hashicorp/nomad v1.10.5 h1:KGQK0Ao9L7xtO/ZagS7tXD8MvFTr5R6y7SiOGhEXzW
 github.com/hashicorp/nomad v1.10.5/go.mod h1:NElc7qdOlCrkoKaJ8jyMo4+oX1U8TIxd8NM1TKtgVYE=
 github.com/hashicorp/nomad/api v0.0.0-20250410143434-48f304d0cab3 h1:TjZj39y7e43IufHDuIFk/EmtRjTpLb41xbds2jLQ/dw=
 github.com/hashicorp/nomad/api v0.0.0-20250410143434-48f304d0cab3/go.mod h1:ke9JNxf926l1gzdv+hldAgk72SgvmrjSos1rRqDJLq8=
+github.com/hashicorp/nomad/api v0.0.0-20251008130118-ee88f65316c3 h1:ioGyuSc+xLS2KRRe62eIq2rBoJ0dzGbGSDx7MhC/Kvk=
+github.com/hashicorp/nomad/api v0.0.0-20251008130118-ee88f65316c3/go.mod h1:sldFTIgs+FsUeKU3LwVjviAIuksxD8TzDOn02MYwslE=
 github.com/hashicorp/terraform-exec v0.23.1 h1:diK5NSSDXDKqHEOIQefBMu9ny+FhzwlwV0xgUTB7VTo=
 github.com/hashicorp/terraform-exec v0.23.1/go.mod h1:e4ZEg9BJDRaSalGm2z8vvrPONt0XWG0/tXpmzYTf+dM=
 github.com/hashicorp/terraform-json v0.27.1 h1:zWhEracxJW6lcjt/JvximOYyc12pS/gaKSy/wzzE7nY=


### PR DESCRIPTION
When we updated the Nomad package in 2.5.1, we forgot to update the Nomad API package as well, so using features like `template.once` are not working.

Fixes: https://github.com/hashicorp/terraform-provider-nomad/issues/548

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

