### PR TITLE
Add muxed framework provider and ephemeral intro token support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## UNRELEASED
 
 IMPROVEMENTS:
+* provider: add a muxed framework provider alongside the existing SDKv2 provider ([#592](https://github.com/hashicorp/terraform-provider-nomad/pull/592))
+* **New Ephemeral Resource**: `nomad_node_intro_token` creates a temporary Nomad client introduction token ([#592](https://github.com/hashicorp/terraform-provider-nomad/pull/592))
 * data source/nomad_jwks: add EdDSA (Ed25519) key support ([#583](https://github.com/hashicorp/terraform-provider-nomad/pull/583))
 * data source/nomad_job_parser: add `variables` parameter to pass HCL2 variables to the job parser ([#582](https://github.com/hashicorp/terraform-provider-nomad/pull/582))
 * resource/nomad_acl_policy: make `job_id` optional in `job_acl` block to allow policies that apply to all jobs in a namespace ([#580](https://github.com/hashicorp/terraform-provider-nomad/pull/580))

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-mux v0.23.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0
+	github.com/hashicorp/terraform-plugin-testing v1.15.0
 	github.com/shoenig/test v1.12.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/exp v0.0.0-20250808145144-a408d31f581a

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,9 @@ require (
 	github.com/hashicorp/go-version v1.8.0
 	github.com/hashicorp/nomad v1.11.3
 	github.com/hashicorp/nomad/api v0.0.0-20260311215651-558bcb13671c
+	github.com/hashicorp/terraform-plugin-framework v1.19.0
+	github.com/hashicorp/terraform-plugin-go v0.31.0
+	github.com/hashicorp/terraform-plugin-mux v0.23.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0
 	github.com/shoenig/test v1.12.2
 	github.com/stretchr/testify v1.11.1
@@ -55,7 +58,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.0 // indirect
 	github.com/hashicorp/terraform-json v0.27.2 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.31.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.10.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/hashicorp/terraform-plugin-mux v0.23.0 h1:YEjYA6kle7vJrVWS+WgyrFoYzUn
 github.com/hashicorp/terraform-plugin-mux v0.23.0/go.mod h1:IwuivHNfDVeuDbVvg6fnAYEEEVx881STwJHsl/00UkQ=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0 h1:MKS/2URqeJRwJdbOfcbdsZCq/IRrNkqJNN0GtVIsuGs=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0/go.mod h1:PuG4P97Ju3QXW6c6vRkRadWJbvnEu2Xh+oOuqcYOqX4=
+github.com/hashicorp/terraform-plugin-testing v1.15.0 h1:/fimKyl0YgD7aAtJkuuAZjwBASXhCIwWqMbDLnKLMe4=
+github.com/hashicorp/terraform-plugin-testing v1.15.0/go.mod h1:bGXMw7bE95EiZhSBV3rM2W8TiffaPTDuLS+HFI/lIYs=
 github.com/hashicorp/terraform-registry-address v0.4.0 h1:S1yCGomj30Sao4l5BMPjTGZmCNzuv7/GDTDX99E9gTk=
 github.com/hashicorp/terraform-registry-address v0.4.0/go.mod h1:LRS1Ay0+mAiRkUyltGT+UHWkIqTFvigGn/LbMshfflE=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/go.sum
+++ b/go.sum
@@ -117,10 +117,14 @@ github.com/hashicorp/terraform-exec v0.25.0 h1:Bkt6m3VkJqYh+laFMrWIpy9KHYFITpOyz
 github.com/hashicorp/terraform-exec v0.25.0/go.mod h1:dl9IwsCfklDU6I4wq9/StFDp7dNbH/h5AnfS1RmiUl8=
 github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoKST/tRDBJKU=
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
+github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
+github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=
 github.com/hashicorp/terraform-plugin-log v0.10.0/go.mod h1:/9RR5Cv2aAbrqcTSdNmY1NRHP4E3ekrXRGjqORpXyB0=
+github.com/hashicorp/terraform-plugin-mux v0.23.0 h1:YEjYA6kle7vJrVWS+WgyrFoYzUnOCJQ0kwGAJ61X9aE=
+github.com/hashicorp/terraform-plugin-mux v0.23.0/go.mod h1:IwuivHNfDVeuDbVvg6fnAYEEEVx881STwJHsl/00UkQ=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0 h1:MKS/2URqeJRwJdbOfcbdsZCq/IRrNkqJNN0GtVIsuGs=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0/go.mod h1:PuG4P97Ju3QXW6c6vRkRadWJbvnEu2Xh+oOuqcYOqX4=
 github.com/hashicorp/terraform-registry-address v0.4.0 h1:S1yCGomj30Sao4l5BMPjTGZmCNzuv7/GDTDX99E9gTk=

--- a/internal/framework/provider/acl/ephemeral_intro_token.go
+++ b/internal/framework/provider/acl/ephemeral_intro_token.go
@@ -1,0 +1,151 @@
+// Copyright IBM Corp. 2016, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package acl
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephemeralschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-provider-nomad/nomad"
+)
+
+var (
+	_ ephemeral.EphemeralResource              = (*IntroTokenEphemeralResource)(nil)
+	_ ephemeral.EphemeralResourceWithConfigure = (*IntroTokenEphemeralResource)(nil)
+)
+
+type IntroTokenEphemeralResource struct {
+	SDKv2Meta func() any
+}
+
+type introTokenModel struct {
+	NodeName types.String `tfsdk:"node_name"`
+	NodePool types.String `tfsdk:"node_pool"`
+	TTL      types.String `tfsdk:"ttl"`
+	JWT      types.String `tfsdk:"jwt"`
+}
+
+func NewIntroTokenEphemeralResource() ephemeral.EphemeralResource {
+	return &IntroTokenEphemeralResource{}
+}
+
+func (r *IntroTokenEphemeralResource) Configure(_ context.Context, req ephemeral.ConfigureRequest, resp *ephemeral.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	sdkv2Meta, ok := req.ProviderData.(func() any)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Ephemeral Resource Configure Type",
+			fmt.Sprintf("Expected provider data of type func() any, got %T.", req.ProviderData),
+		)
+		return
+	}
+
+	r.SDKv2Meta = sdkv2Meta
+}
+
+func (r *IntroTokenEphemeralResource) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_node_intro_token"
+}
+
+func (r *IntroTokenEphemeralResource) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = ephemeralschema.Schema{
+		Attributes: map[string]ephemeralschema.Attribute{
+			"node_name": ephemeralschema.StringAttribute{
+				Optional:    true,
+				Description: "The node name to scope the introduction token to.",
+			},
+			"node_pool": ephemeralschema.StringAttribute{
+				Optional:    true,
+				Description: "The node pool to scope the introduction token to.",
+			},
+			"ttl": ephemeralschema.StringAttribute{
+				Optional:    true,
+				Description: "Requested introduction token TTL, such as 5m or 1h.",
+			},
+			"jwt": ephemeralschema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The signed JWT node introduction token.",
+			},
+		},
+	}
+}
+
+func (r *IntroTokenEphemeralResource) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data introTokenModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		log.Printf("[DEBUG] nomad_node_intro_token: config decoding returned diagnostics")
+		return
+	}
+
+	if r.SDKv2Meta == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured Nomad Provider",
+			"The provider has not been configured. Configure the nomad provider before using nomad_node_intro_token.",
+		)
+		return
+	}
+
+	providerData := r.SDKv2Meta()
+	providerConfig, ok := providerData.(nomad.ProviderConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider Metadata Type",
+			fmt.Sprintf("Expected nomad.ProviderConfig, got %T.", providerData),
+		)
+		return
+	}
+
+	request := &api.ACLIdentityClientIntroductionTokenRequest{}
+	if !data.NodeName.IsNull() && !data.NodeName.IsUnknown() {
+		request.NodeName = data.NodeName.ValueString()
+	}
+	if !data.NodePool.IsNull() && !data.NodePool.IsUnknown() {
+		request.NodePool = data.NodePool.ValueString()
+	}
+	if !data.TTL.IsNull() && !data.TTL.IsUnknown() {
+		ttl, err := time.ParseDuration(data.TTL.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid TTL", fmt.Sprintf("Failed to parse ttl %q: %v", data.TTL.ValueString(), err))
+			return
+		}
+		request.TTL = ttl
+	}
+
+	client := providerConfig.Client()
+	if client == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured Nomad Client",
+			"The provider did not expose a configured Nomad API client.",
+		)
+		return
+	}
+
+	log.Printf("[DEBUG] nomad_node_intro_token: creating client introduction token")
+	introToken, _, err := client.ACLIdentity().CreateClientIntroductionToken(request, nil)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Create Node Introduction Token",
+			err.Error(),
+		)
+		return
+	}
+
+	log.Printf("[DEBUG] nomad_node_intro_token: successfully created introduction token")
+	data.JWT = types.StringValue(introToken.JWT)
+
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}

--- a/internal/framework/provider/acl/ephemeral_intro_token_test.go
+++ b/internal/framework/provider/acl/ephemeral_intro_token_test.go
@@ -1,0 +1,112 @@
+// Copyright IBM Corp. 2017, 2026
+
+package acl_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	sdkv2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider"
+	"github.com/hashicorp/terraform-provider-nomad/nomad"
+)
+
+func TestAccEphemeralIntroToken_basic(t *testing.T) {
+	const nodeName = "acctest-node-intro"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEphemeralIntroTokenConfig(nodeName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"echo.test",
+						tfjsonpath.New("data").AtMapKey("node_name"),
+						knownvalue.StringExact(nodeName),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.test",
+						tfjsonpath.New("data").AtMapKey("ttl"),
+						knownvalue.StringExact("5m"),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.test",
+						tfjsonpath.New("data").AtMapKey("jwt"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccEphemeralIntroTokenConfig(nodeName string) string {
+	return fmt.Sprintf(`
+provider "nomad" {}
+
+ephemeral "nomad_node_intro_token" "test" {
+  node_name = %q
+  ttl       = "5m"
+}
+
+provider "echo" {
+  data = ephemeral.nomad_node_intro_token.test
+}
+
+resource "echo" "test" {}
+`, nodeName)
+}
+
+func sdkv2providerMeta(t *testing.T) func() any {
+	t.Helper()
+
+	p := nomad.Provider()
+	if err := p.Configure(context.Background(), sdkv2.NewResourceConfigRaw(nil)); err != nil {
+		t.Fatalf("failed to configure sdkv2 provider: %v", err)
+	}
+
+	return p.Meta
+}
+
+func testAccProtoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
+	return map[string]func() (tfprotov6.ProviderServer, error){
+		"nomad": func() (tfprotov6.ProviderServer, error) {
+			return providerserver.NewProtocol6WithError(provider.New(sdkv2providerMetaForFactory()))()
+		},
+		"echo": echoprovider.NewProviderServer(),
+	}
+}
+
+func sdkv2providerMetaForFactory() func() any {
+	p := nomad.Provider()
+	if err := p.Configure(context.Background(), sdkv2.NewResourceConfigRaw(nil)); err != nil {
+		panic(fmt.Sprintf("failed to configure sdkv2 provider: %v", err))
+	}
+
+	return p.Meta
+}
+
+func testAccPreCheck(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv("NOMAD_ADDR") == "" {
+		os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	}
+
+	_ = sdkv2providerMeta(t)
+}

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -1,0 +1,151 @@
+// Copyright IBM Corp. 2016, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	frameworkprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	provideracl "github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/acl"
+)
+
+// Ensure NomadProvider satisfies various provider interfaces.
+var (
+	_ frameworkprovider.Provider                       = (*NomadProvider)(nil)
+	_ frameworkprovider.ProviderWithEphemeralResources = (*NomadProvider)(nil)
+)
+
+type NomadProvider struct {
+	// SDKv2Meta is a function which returns provider meta struct from the SDKv2 code
+	SDKv2Meta func() any
+}
+
+func New(sdkv2Meta func() any) frameworkprovider.Provider {
+	return &NomadProvider{
+		SDKv2Meta: sdkv2Meta,
+	}
+}
+
+func (p *NomadProvider) Metadata(_ context.Context, _ frameworkprovider.MetadataRequest, resp *frameworkprovider.MetadataResponse) {
+	resp.TypeName = "nomad"
+}
+
+func (p *NomadProvider) Schema(_ context.Context, _ frameworkprovider.SchemaRequest, resp *frameworkprovider.SchemaResponse) {
+	resp.Schema = providerschema.Schema{
+		Attributes: map[string]providerschema.Attribute{
+			"address": providerschema.StringAttribute{
+				Optional:    true,
+				Description: "URL of the root of the target Nomad agent.",
+			},
+			"region": providerschema.StringAttribute{
+				Optional:    true,
+				Description: "Region of the target Nomad agent.",
+			},
+			"http_auth": providerschema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "HTTP basic auth configuration.",
+			},
+			"ca_file": providerschema.StringAttribute{
+				Optional:    true,
+				Description: "A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.",
+			},
+			"ca_pem": providerschema.StringAttribute{
+				Optional:    true,
+				Description: "PEM-encoded certificate authority used to verify the remote agent's certificate.",
+			},
+			"cert_file": providerschema.StringAttribute{
+				Optional:    true,
+				Description: "A path to a PEM-encoded certificate provided to the remote agent; requires use of key_file or key_pem.",
+			},
+			"cert_pem": providerschema.StringAttribute{
+				Optional:    true,
+				Description: "PEM-encoded certificate provided to the remote agent; requires use of key_file or key_pem.",
+			},
+			"key_file": providerschema.StringAttribute{
+				Optional:    true,
+				Description: "A path to a PEM-encoded private key, required if cert_file or cert_pem is specified.",
+			},
+			"key_pem": providerschema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "PEM-encoded private key, required if cert_file or cert_pem is specified.",
+			},
+			"secret_id": providerschema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "ACL token secret for API requests.",
+			},
+			"ignore_env_vars": providerschema.MapAttribute{
+				Optional:    true,
+				ElementType: types.BoolType,
+				Description: "A set of environment variables that are ignored by the provider when configuring the Nomad API client.",
+			},
+			"skip_verify": providerschema.BoolAttribute{
+				Optional:    true,
+				Description: "Skip TLS verification on client side.",
+			},
+		},
+		Blocks: map[string]providerschema.Block{
+			"headers": providerschema.ListNestedBlock{
+				Description: "The headers to send with each Nomad request.",
+				NestedObject: providerschema.NestedBlockObject{
+					Attributes: map[string]providerschema.Attribute{
+						"name": providerschema.StringAttribute{
+							Required:    true,
+							Description: "The header name",
+						},
+						"value": providerschema.StringAttribute{
+							Required:    true,
+							Sensitive:   true,
+							Description: "The header value",
+						},
+					},
+				},
+			},
+			"auth_jwt": providerschema.ListNestedBlock{
+				Description: "Authenticates to Nomad using a JWT authentication method.",
+				Validators:  nil,
+				NestedObject: providerschema.NestedBlockObject{
+					Attributes: map[string]providerschema.Attribute{
+						"auth_method": providerschema.StringAttribute{
+							Required:    true,
+							Description: "The name of the auth method to use for login.",
+						},
+						"login_token": providerschema.StringAttribute{
+							Required:    true,
+							Sensitive:   true,
+							Description: "The externally issued authentication token to be exchanged for a Nomad ACL Token.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (p *NomadProvider) Configure(_ context.Context, _ frameworkprovider.ConfigureRequest, resp *frameworkprovider.ConfigureResponse) {
+	resp.ResourceData = p.SDKv2Meta
+	resp.DataSourceData = p.SDKv2Meta
+	resp.EphemeralResourceData = p.SDKv2Meta
+}
+
+func (p *NomadProvider) Resources(_ context.Context) []func() resource.Resource {
+	return nil
+}
+
+func (p *NomadProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return nil
+}
+
+func (p *NomadProvider) EphemeralResources(_ context.Context) []func() ephemeral.EphemeralResource {
+	return []func() ephemeral.EphemeralResource{
+		provideracl.NewIntroTokenEphemeralResource,
+	}
+}

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -1,0 +1,31 @@
+// Copyright IBM Corp. 2016, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package mux
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+	framework "github.com/hashicorp/terraform-provider-nomad/internal/framework/provider"
+	"github.com/hashicorp/terraform-provider-nomad/nomad"
+)
+
+func MuxServer(ctx context.Context) (tfprotov6.ProviderServer, error) {
+	sdkProvider := nomad.Provider()
+
+	upgradedSDKProvider, err := tf5to6server.UpgradeServer(ctx, sdkProvider.GRPCProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	providers := []func() tfprotov6.ProviderServer{
+		func() tfprotov6.ProviderServer { return upgradedSDKProvider },
+		providerserver.NewProtocol6(framework.New(sdkProvider.Meta)),
+	}
+
+	return tf6muxserver.NewMuxServer(ctx, providers...)
+}

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -1,0 +1,99 @@
+// Copyright IBM Corp. 2016, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package mux
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+	"nomad": func() (tfprotov6.ProviderServer, error) {
+		return MuxServer(context.Background())
+	},
+}
+
+func TestMuxServer_MetadataAndSchema(t *testing.T) {
+	t.Parallel()
+
+	server, err := MuxServer(context.Background())
+	if err != nil {
+		t.Fatalf("expected mux server to initialize: %v", err)
+	}
+
+	metadata, err := server.GetMetadata(context.Background(), &tfprotov6.GetMetadataRequest{})
+	if err != nil {
+		t.Fatalf("expected metadata from mux server: %v", err)
+	}
+
+	if !containsDataSource(metadata.DataSources, "nomad_regions") {
+		t.Fatalf("expected nomad_regions data source in mux metadata")
+	}
+
+	if !containsEphemeralResource(metadata.EphemeralResources, "nomad_node_intro_token") {
+		t.Fatalf("expected nomad_node_intro_token ephemeral resource in mux metadata")
+	}
+
+	schema, err := server.GetProviderSchema(context.Background(), &tfprotov6.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("expected provider schema from mux server: %v", err)
+	}
+
+	if schema.Provider == nil {
+		t.Fatal("expected provider schema to be returned")
+	}
+
+	if _, ok := schema.DataSourceSchemas["nomad_regions"]; !ok {
+		t.Fatal("expected nomad_regions schema from mux server")
+	}
+
+	if _, ok := schema.EphemeralResourceSchemas["nomad_node_intro_token"]; !ok {
+		t.Fatal("expected nomad_node_intro_token schema from mux server")
+	}
+}
+
+func TestAccMuxProvider_RegionsDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			if os.Getenv("NOMAD_ADDR") == "" {
+				os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+			}
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+provider "nomad" {}
+
+data "nomad_regions" "test" {}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.nomad_regions.test", "regions.#"),
+				),
+			},
+		},
+	})
+}
+
+func containsDataSource(dataSources []tfprotov6.DataSourceMetadata, typeName string) bool {
+	for _, dataSource := range dataSources {
+		if dataSource.TypeName == typeName {
+			return true
+		}
+	}
+	return false
+}
+
+func containsEphemeralResource(ephemeralResources []tfprotov6.EphemeralResourceMetadata, typeName string) bool {
+	for _, ephemeralResource := range ephemeralResources {
+		if ephemeralResource.TypeName == typeName {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -21,12 +21,14 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 func TestMuxServer_MetadataAndSchema(t *testing.T) {
 	t.Parallel()
 
-	server, err := MuxServer(context.Background())
+	ctx := t.Context()
+
+	server, err := MuxServer(ctx)
 	if err != nil {
 		t.Fatalf("expected mux server to initialize: %v", err)
 	}
 
-	metadata, err := server.GetMetadata(context.Background(), &tfprotov6.GetMetadataRequest{})
+	metadata, err := server.GetMetadata(ctx, &tfprotov6.GetMetadataRequest{})
 	if err != nil {
 		t.Fatalf("expected metadata from mux server: %v", err)
 	}
@@ -39,7 +41,7 @@ func TestMuxServer_MetadataAndSchema(t *testing.T) {
 		t.Fatalf("expected nomad_node_intro_token ephemeral resource in mux metadata")
 	}
 
-	schema, err := server.GetProviderSchema(context.Background(), &tfprotov6.GetProviderSchemaRequest{})
+	schema, err := server.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
 	if err != nil {
 		t.Fatalf("expected provider schema from mux server: %v", err)
 	}

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/main.go
+++ b/main.go
@@ -4,14 +4,27 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"context"
+	"log"
 
-	"github.com/hashicorp/terraform-provider-nomad/nomad"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
+
+	"github.com/hashicorp/terraform-provider-nomad/internal/mux"
+)
+
+const (
+	providerName = "registry.terraform.io/hashicorp/nomad"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: func() *schema.Provider { return nomad.Provider() },
-	})
+	ctx := context.Background()
+	muxServer, err := mux.MuxServer(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := tf6server.Serve(providerName, func() tfprotov6.ProviderServer { return muxServer }); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/nomad/data_source_acl_policies.go
+++ b/nomad/data_source_acl_policies.go
@@ -8,7 +8,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -66,7 +66,7 @@ func dataSourceAclPoliciesRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error getting ACL policies: %#v", err)
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 	if err := d.Set("policies", flattenAclPolicies(policies)); err != nil {
 		return fmt.Errorf("error setting policies: %#v", err)
 	}

--- a/nomad/data_source_acl_policies_test.go
+++ b/nomad/data_source_acl_policies_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDataSourceNomadAclPolicies_Basic(t *testing.T) {

--- a/nomad/data_source_acl_policy_test.go
+++ b/nomad/data_source_acl_policy_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDataSourceNomadAclPolicy_Basic(t *testing.T) {

--- a/nomad/data_source_acl_role_test.go
+++ b/nomad/data_source_acl_role_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestDataSourceACLRole(t *testing.T) {

--- a/nomad/data_source_acl_roles_test.go
+++ b/nomad/data_source_acl_roles_test.go
@@ -6,7 +6,7 @@ package nomad
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestDataSourceACLRoles(t *testing.T) {

--- a/nomad/data_source_acl_token_test.go
+++ b/nomad/data_source_acl_token_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestDataSourceACLToken_Basic(t *testing.T) {

--- a/nomad/data_source_acl_tokens_test.go
+++ b/nomad/data_source_acl_tokens_test.go
@@ -6,7 +6,7 @@ package nomad
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestDataSourceACLTokens_Basic(t *testing.T) {

--- a/nomad/data_source_allocations_test.go
+++ b/nomad/data_source_allocations_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
 )

--- a/nomad/data_source_datacenters.go
+++ b/nomad/data_source_datacenters.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -51,7 +51,7 @@ func dataSourceDatacentersRead(d *schema.ResourceData, meta interface{}) error {
 	prefix := d.Get("prefix").(string)
 	ignoreDown := d.Get("ignore_down_nodes").(bool)
 
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 	if err := d.Set("datacenters", filterDatacenters(nodes, prefix, ignoreDown)); err != nil {
 		return fmt.Errorf("error setting datacenters: %v", err)
 	}

--- a/nomad/data_source_datacenters_test.go
+++ b/nomad/data_source_datacenters_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDataSourceDatacenters_Basic(t *testing.T) {

--- a/nomad/data_source_deployments_test.go
+++ b/nomad/data_source_deployments_test.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // Test will

--- a/nomad/data_source_job_parser_test.go
+++ b/nomad/data_source_job_parser_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDataSourceNomadJobParser_Basic(t *testing.T) {

--- a/nomad/data_source_jwks_test.go
+++ b/nomad/data_source_jwks_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 const testAccNomadJWKSConfig = `data "nomad_jwks" "test" {}`

--- a/nomad/data_source_namespace_test.go
+++ b/nomad/data_source_namespace_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestDataSourceNamespace(t *testing.T) {

--- a/nomad/data_source_namespaces_test.go
+++ b/nomad/data_source_namespaces_test.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestDataSourceNamespaces(t *testing.T) {

--- a/nomad/data_source_node_pool_test.go
+++ b/nomad/data_source_node_pool_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestDataSourceNodePool(t *testing.T) {

--- a/nomad/data_source_node_pools_test.go
+++ b/nomad/data_source_node_pools_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestDataSourceNodePools_basic(t *testing.T) {

--- a/nomad/data_source_node_test.go
+++ b/nomad/data_source_node_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestDataSourceNode_basic(t *testing.T) {

--- a/nomad/data_source_nodes_test.go
+++ b/nomad/data_source_nodes_test.go
@@ -6,7 +6,7 @@ package nomad
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestDataSourceNodes_basic(t *testing.T) {

--- a/nomad/data_source_regions_test.go
+++ b/nomad/data_source_regions_test.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestDataSourceRegions(t *testing.T) {

--- a/nomad/data_source_scaling_policies.go
+++ b/nomad/data_source_scaling_policies.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -76,7 +76,7 @@ func scalingPoliciesDataSourceRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("failed to query scaling policies: %v", err)
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 
 	if err := d.Set("policies", flattenScalingPolicies(policies)); err != nil {
 		return fmt.Errorf("failed to set policies: %v", err)

--- a/nomad/data_source_scaling_policies_test.go
+++ b/nomad/data_source_scaling_policies_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestDataSourceScalingPolicies_Basic(t *testing.T) {

--- a/nomad/data_source_scaling_policy_test.go
+++ b/nomad/data_source_scaling_policy_test.go
@@ -6,7 +6,7 @@ package nomad
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestDataSourceScalingPolicy_Basic(t *testing.T) {

--- a/nomad/data_source_scheduler_config.go
+++ b/nomad/data_source_scheduler_config.go
@@ -6,7 +6,7 @@ package nomad
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-nomad/nomad/helper"
 )
@@ -46,7 +46,7 @@ func dataSourceSchedulerConfigRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// Set a unique ID, as we have nothing else to go on.
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 
 	premptMap := map[string]bool{
 		"batch_scheduler_enabled":    schedCfg.SchedulerConfig.PreemptionConfig.BatchSchedulerEnabled,

--- a/nomad/datasource_nomad_job.go
+++ b/nomad/datasource_nomad_job.go
@@ -6,6 +6,7 @@ package nomad
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
@@ -67,7 +68,7 @@ func dataSourceJob() *schema.Resource {
 			},
 			"submit_time": {
 				Description: "Job Submit Time",
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"create_index": {
@@ -198,7 +199,11 @@ func dataSourceJobRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("datacenters", job.Datacenters)
 	d.Set("status", job.Status)
 	d.Set("status_description", job.StatusDescription)
-	d.Set("submit_time", job.SubmitTime)
+	if job.SubmitTime != nil {
+		d.Set("submit_time", strconv.FormatInt(*job.SubmitTime, 10))
+	} else {
+		d.Set("submit_time", "")
+	}
 	d.Set("create_index", job.CreateIndex)
 	d.Set("modify_index", job.ModifyIndex)
 	d.Set("job_modify_index", job.JobModifyIndex)

--- a/nomad/datasource_nomad_job_test.go
+++ b/nomad/datasource_nomad_job_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDataSourceNomadJob_Basic(t *testing.T) {

--- a/nomad/datasource_nomad_plugin.go
+++ b/nomad/datasource_nomad_plugin.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -96,9 +96,11 @@ func dataSourcePluginRead(d *schema.ResourceData, meta interface{}) error {
 	wait := d.Get("wait_for_registration").(bool)
 	waitForHealthy := d.Get("wait_for_healthy").(bool)
 	if wait || waitForHealthy {
-		resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+		if err := retry.Retry(d.Timeout(schema.TimeoutRead), func() *retry.RetryError {
 			return getPluginInfo(client, d)
-		})
+		}); err != nil {
+			return err
+		}
 	} else {
 		err := getPluginInfo(client, d)
 		if err != nil {
@@ -109,7 +111,7 @@ func dataSourcePluginRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func getPluginInfo(client *api.Client, d *schema.ResourceData) *resource.RetryError {
+func getPluginInfo(client *api.Client, d *schema.ResourceData) *retry.RetryError {
 	id := d.Get("plugin_id").(string)
 	waitForHealthy := d.Get("wait_for_healthy").(bool)
 
@@ -120,9 +122,9 @@ func getPluginInfo(client *api.Client, d *schema.ResourceData) *resource.RetryEr
 		// rather than a nil result, so we must check this way.
 		log.Printf("[ERROR] error checking for plugin: %#v", err)
 		if strings.Contains(err.Error(), "404") {
-			return resource.RetryableError(fmt.Errorf("plugin %q not found", id))
+			return retry.RetryableError(fmt.Errorf("plugin %q not found", id))
 		}
-		return resource.NonRetryableError(fmt.Errorf("error checking for plugin: %#v", err))
+		return retry.NonRetryableError(fmt.Errorf("error checking for plugin: %#v", err))
 	}
 
 	healthy := plugin.ControllersExpected == plugin.ControllersHealthy &&
@@ -134,7 +136,7 @@ func getPluginInfo(client *api.Client, d *schema.ResourceData) *resource.RetryEr
 			plugin.ControllersHealthy, plugin.ControllersExpected,
 			plugin.NodesHealthy, plugin.NodesExpected)
 
-		return resource.RetryableError(fmt.Errorf("plugin %s not yet healthy", id))
+		return retry.RetryableError(fmt.Errorf("plugin %s not yet healthy", id))
 	}
 
 	d.SetId(plugin.ID)

--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -39,6 +39,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NOMAD_HTTP_AUTH", ""),
+				Sensitive:   true,
 				Description: "HTTP basic auth configuration.",
 			},
 			"ca_file": {
@@ -77,6 +78,7 @@ func Provider() *schema.Provider {
 			"key_pem": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Sensitive:     true,
 				Description:   "PEM-encoded private key, required if cert_file or cert_pem is specified.",
 				ConflictsWith: []string{"key_file"},
 			},
@@ -84,6 +86,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NOMAD_TOKEN", ""),
+				Sensitive:   true,
 				Description: "ACL token secret for API requests.",
 			},
 			"headers": {
@@ -101,6 +104,7 @@ func Provider() *schema.Provider {
 						"value": {
 							Type:        schema.TypeString,
 							Required:    true,
+							Sensitive:   true,
 							Description: "The header value",
 						},
 					},
@@ -121,6 +125,7 @@ func Provider() *schema.Provider {
 						"login_token": {
 							Type:        schema.TypeString,
 							Required:    true,
+							Sensitive:   true,
 							Description: "The externally issued authentication token to be exchanged for a Nomad ACL Token.",
 						},
 					},
@@ -333,4 +338,12 @@ func nonPooledHttpClient() *http.Client {
 	transport.ForceAttemptHTTP2 = false
 
 	return httpClient
+}
+
+func (p ProviderConfig) Client() *api.Client {
+	return p.client
+}
+
+func (p ProviderConfig) Config() *api.Config {
+	return p.config
 }

--- a/nomad/provider_test.go
+++ b/nomad/provider_test.go
@@ -13,9 +13,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	sdkterraform "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // How to run the acceptance tests for this provider:
@@ -68,7 +69,7 @@ func testAccPreCheck(t *testing.T) {
 		os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
 	}
 
-	err := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
+	err := testProvider.Configure(context.Background(), sdkterraform.NewResourceConfigRaw(nil))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nomad/resource_acl_auth_method_test.go
+++ b/nomad/resource_acl_auth_method_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"golang.org/x/exp/slices"
 )
 

--- a/nomad/resource_acl_binding_rule_test.go
+++ b/nomad/resource_acl_binding_rule_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceACLBindingRule(t *testing.T) {

--- a/nomad/resource_acl_policy_test.go
+++ b/nomad/resource_acl_policy_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceACLPolicy_import(t *testing.T) {

--- a/nomad/resource_acl_role_test.go
+++ b/nomad/resource_acl_role_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceACLRole(t *testing.T) {

--- a/nomad/resource_acl_token_test.go
+++ b/nomad/resource_acl_token_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceACLToken_import(t *testing.T) {

--- a/nomad/resource_csi_volume_test.go
+++ b/nomad/resource_csi_volume_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 )

--- a/nomad/resource_dynamic_host_volume_registration_test.go
+++ b/nomad/resource_dynamic_host_volume_registration_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testResourceNameDynamicHostVolumeRegister = "nomad_dynamic_host_volume_registration.test"

--- a/nomad/resource_dynamic_host_volume_test.go
+++ b/nomad/resource_dynamic_host_volume_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
 )

--- a/nomad/resource_external_volume_test.go
+++ b/nomad/resource_external_volume_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // Testing this resource requires access to a Nomad cluster with CSI plugins

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -168,7 +168,7 @@ func resourceJob() *schema.Resource {
 			"submit_time": {
 				Description: "The time the job was submitted.",
 				Computed:    true,
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 			},
 
 			"create_index": {
@@ -761,7 +761,11 @@ func resourceJobRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("status", job.Status)
 	d.Set("status_description", job.StatusDescription)
 	d.Set("version", job.Version)
-	d.Set("submit_time", job.SubmitTime)
+	if job.SubmitTime != nil {
+		d.Set("submit_time", strconv.FormatInt(*job.SubmitTime, 10))
+	} else {
+		d.Set("submit_time", "")
+	}
 	d.Set("create_index", job.CreateIndex)
 	d.Set("stop", job.Stop)
 	d.Set("priority", job.Priority)

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-provider-nomad/nomad/helper/pointer"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceJob_basic(t *testing.T) {

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -3153,10 +3153,14 @@ func TestResourceJob_externalStop(t *testing.T) {
 				Check:  testResourceJob_statusCheck(t, "running"),
 			},
 			// Simulate an external job stop.
-			// Expect non-empty plan since job should rerun.
 			{
-				Config:             testResourceJob_rerunIfDead(jobID, true),
-				Check:              testResourceJob_externalStopCheck(t),
+				Config: testResourceJob_rerunIfDead(jobID, true),
+				Check:  testResourceJob_externalStopCheck(t),
+			},
+			// Refresh state and expect drift since rerun_if_dead should cause the
+			// job to be started again on the next apply.
+			{
+				RefreshState:       true,
 				ExpectNonEmptyPlan: true,
 			},
 			// Verify job reruns on apply.

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -3135,11 +3135,9 @@ func TestResourceJob_externalStop(t *testing.T) {
 				Config: testResourceJob_rerunIfDead(jobID, false),
 				Check:  testResourceJob_initialCheck(t),
 			},
-			// Simulate an external job stop.
-			// Expect empty plan since nothing should happen.
 			{
-				Config:             testResourceJob_rerunIfDead(jobID, false),
-				Check:              testResourceJob_externalStopCheck(t),
+				PreConfig:          testResourceJob_deregister(t, jobID),
+				RefreshState:       true,
 				ExpectNonEmptyPlan: false,
 			},
 			// Verify job doesn't rerun on apply.
@@ -3152,14 +3150,8 @@ func TestResourceJob_externalStop(t *testing.T) {
 				Config: testResourceJob_rerunIfDead(jobID, true),
 				Check:  testResourceJob_statusCheck(t, "running"),
 			},
-			// Simulate an external job stop.
 			{
-				Config: testResourceJob_rerunIfDead(jobID, true),
-				Check:  testResourceJob_externalStopCheck(t),
-			},
-			// Refresh state and expect drift since rerun_if_dead should cause the
-			// job to be started again on the next apply.
-			{
+				PreConfig:          testResourceJob_deregister(t, jobID),
 				RefreshState:       true,
 				ExpectNonEmptyPlan: true,
 			},
@@ -3194,32 +3186,6 @@ EOT
   rerun_if_dead = %t
 }
 `, name, rerunIfDead)
-}
-
-func testResourceJob_externalStopCheck(t *testing.T) r.TestCheckFunc {
-	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["nomad_job.test"]
-		if resourceState == nil {
-			return errors.New("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return errors.New("resource has no primary instance")
-		}
-
-		jobID := instanceState.ID
-		providerConfig := testProvider.Meta().(ProviderConfig)
-		client := providerConfig.client
-		_, _, err := client.Jobs().Deregister(jobID, false, &api.WriteOptions{
-			Namespace: instanceState.Attributes["namespace"],
-		})
-		if err != nil {
-			return fmt.Errorf("error deregistering job: %s", err)
-		}
-
-		return nil
-	}
 }
 
 func testResourceJob_statusCheck(t *testing.T, status string) r.TestCheckFunc {

--- a/nomad/resource_namespace_test.go
+++ b/nomad/resource_namespace_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceNamespace_import(t *testing.T) {

--- a/nomad/resource_node_pool_test.go
+++ b/nomad/resource_node_pool_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceNodePool_import(t *testing.T) {

--- a/nomad/resource_quota_specification_test.go
+++ b/nomad/resource_quota_specification_test.go
@@ -31,6 +31,12 @@ func TestResourceQuotaSpecification_import(t *testing.T) {
 				ResourceName:      "nomad_quota_specification.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"limits.0.region_limit.0.cores",
+					"limits.0.region_limit.0.memory_mb",
+					"limits.0.region_limit.0.memory_max_mb",
+					"limits.0.region_limit.0.secrets_mb",
+				},
 			},
 		},
 

--- a/nomad/resource_quota_specification_test.go
+++ b/nomad/resource_quota_specification_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/nomad/api"
 )

--- a/nomad/resource_scheduler_config_test.go
+++ b/nomad/resource_scheduler_config_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestSchedulerConfig_basic(t *testing.T) {

--- a/nomad/resource_scheduler_config_test.go
+++ b/nomad/resource_scheduler_config_test.go
@@ -163,8 +163,12 @@ func TestSchedulerConfig_memoryOversubscriptionEnabledOutsideTest(t *testing.T) 
 					}
 					log.Printf("[DEBUG] Upserted scheduler configuration")
 				},
-				Config:             testAccNomadSchedulerConfigMemoryOversubscription,
 				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config:             testAccNomadSchedulerConfigMemoryOversubscription,
+				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
 		},

--- a/nomad/resource_scheduler_config_test.go
+++ b/nomad/resource_scheduler_config_test.go
@@ -164,7 +164,7 @@ func TestSchedulerConfig_memoryOversubscriptionEnabledOutsideTest(t *testing.T) 
 					log.Printf("[DEBUG] Upserted scheduler configuration")
 				},
 				Config:             testAccNomadSchedulerConfigMemoryOversubscription,
-				PlanOnly:           true,
+				RefreshState:       true,
 				ExpectNonEmptyPlan: false,
 			},
 		},

--- a/nomad/resource_sentinel_policy_test.go
+++ b/nomad/resource_sentinel_policy_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceSentinelPolicy_import(t *testing.T) {

--- a/nomad/resource_variable_test.go
+++ b/nomad/resource_variable_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceVariable_basic(t *testing.T) {

--- a/website/docs/e/node_intro_token.html.markdown
+++ b/website/docs/e/node_intro_token.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_node_intro_token"
+sidebar_current: "docs-nomad-ephemeral-node-intro-token"
+description: |-
+  Creates a short-lived Nomad client introduction token as an ephemeral resource.
+---
+
+# nomad_node_intro_token
+
+Creates a short-lived Nomad client introduction token using an `ephemeral` block.
+
+This ephemeral resource is useful when you need a temporary JWT for Nomad client
+bootstrap or enrollment flows without persisting that token in Terraform state.
+
+## Example Usage
+
+```hcl
+ephemeral "nomad_node_intro_token" "client" {
+  node_name = "bootstrap-client"
+  node_pool = "default"
+  ttl       = "15m"
+}
+
+# Reference the signed JWT as:
+# ephemeral.nomad_node_intro_token.client.jwt
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `node_name` `(string: "")` - The node name to scope the introduction token to.
+
+- `node_pool` `(string: "")` - The node pool to scope the introduction token to.
+
+- `ttl` `(string: "")` - The requested token TTL as a duration such as `"5m"`
+  or `"1h"`.
+
+## Attributes Reference
+
+In addition to the above arguments, the following attribute is exported:
+
+- `jwt` `(string, sensitive)` - The signed JWT node introduction token returned
+  by Nomad.
+
+## Notes
+
+- This ephemeral resource requires a configured `nomad` provider with access to
+  the ACL identity API.
+
+- `ttl` must be a valid Go duration string accepted by Nomad, such as `"30s"`,
+  `"5m"`, or `"1h"`.
+
+- If `node_name` or `node_pool` are omitted, the token is created without those
+  optional request fields.

--- a/website/nomad.erb
+++ b/website/nomad.erb
@@ -115,6 +115,15 @@
             </li>
           </ul>
         </li>
+
+        <li<%= sidebar_current("docs-nomad-ephemeral") %>>
+          <a href="#">Ephemeral Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-nomad-ephemeral-node-intro-token") %>>
+              <a href="/docs/providers/nomad/e/node_intro_token.html">nomad_node_intro_token</a>
+            </li>
+          </ul>
+        </li>
       </ul>
     </div>
   <% end %>


### PR DESCRIPTION
- introduce a protocol v6 mux server combining the current SDKv2 provider with a new framework provider
- keep existing SDKv2 resources/datasources unchanged while adding a framework-only ephemeral resource: `nomad_node_intro_token`
- reuse SDKv2 provider metadata from the framework provider so the framework resource can use the already-configured Nomad client instead of duplicating provider configuration logic
- placed the intro token implementation under `internal/framework/provider/acl`
- align provider schema sensitivity between SDKv2 and framework definitions for secret-bearing fields
- add focused mux tests for merged metadata/schema and an SDK data source through the muxed provider
- migrate SDKv2 testing helper packages to `terraform-plugin-testing`

[JIRA Ticket](https://hashicorp.atlassian.net/browse/NMD-1298)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

