### PR TITLE
remove secretsMB as it's not a quota field

### DIFF
--- a/nomad/resource_quota_specification.go
+++ b/nomad/resource_quota_specification.go
@@ -86,10 +86,6 @@ func resourceQuotaSpecificationRegionLimits() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"secrets_mb": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
 			"devices": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -160,10 +156,6 @@ func resourceQuotaSpecificationNodePools() *schema.Resource {
 				Optional: true,
 			},
 			"memory_max_mb": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"secrets_mb": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
@@ -316,9 +308,6 @@ func flattenQuotaRegionLimit(limit *api.QuotaResources) *schema.Set {
 	if limit.MemoryMaxMB != nil {
 		result["memory_max_mb"] = *limit.MemoryMaxMB
 	}
-	if limit.SecretsMB != nil {
-		result["secrets_mb"] = *limit.SecretsMB
-	}
 	if len(limit.Devices) > 0 {
 		result["devices"] = flattenQuotaDevices(limit.Devices)
 	}
@@ -368,9 +357,6 @@ func flattenQuotaNodePools(pools []*api.NodePoolLimit) []any {
 		}
 		if p.MemoryMaxMB != nil {
 			pool["memory_max_mb"] = *p.MemoryMaxMB
-		}
-		if p.SecretsMB != nil {
-			pool["secrets_mb"] = *p.SecretsMB
 		}
 		if len(p.Devices) > 0 {
 			pool["devices"] = flattenQuotaDevices(p.Devices)
@@ -452,13 +438,6 @@ func expandRegionLimit(limit interface{}) (*api.QuotaResources, error) {
 		}
 		res.MemoryMaxMB = &m
 	}
-	if secrets, ok := regLimit["secrets_mb"]; ok {
-		s, ok := secrets.(int)
-		if !ok {
-			return nil, fmt.Errorf("expected secrets_mb to be int, got %T", secrets)
-		}
-		res.SecretsMB = &s
-	}
 	if devices, ok := regLimit["devices"]; ok {
 		devList := devices.([]interface{})
 		for _, d := range devList {
@@ -507,13 +486,6 @@ func expandRegionLimit(limit interface{}) (*api.QuotaResources, error) {
 					return nil, fmt.Errorf("expected node_pool memory_max to be int, got %T", memMax)
 				}
 				np.MemoryMaxMB = &m
-			}
-			if secrets, ok := pool["secrets_mb"]; ok {
-				s, ok := secrets.(int)
-				if !ok {
-					return nil, fmt.Errorf("expected node_pool secrets_mb to be int, got %T", secrets)
-				}
-				np.SecretsMB = &s
 			}
 			if devices, ok := pool["devices"]; ok {
 				devList := devices.([]interface{})

--- a/nomad/resource_quota_specification_test.go
+++ b/nomad/resource_quota_specification_test.go
@@ -404,7 +404,6 @@ resource "nomad_quota_specification" "test" {
       cores         = 4
       memory_mb     = 2048
       memory_max_mb = 4096
-      secrets_mb    = 512
 
       devices {
         name  = "gpu"
@@ -417,7 +416,6 @@ resource "nomad_quota_specification" "test" {
 				cores         = 2
 				memory_mb     = 1024
 				memory_max_mb = 2048
-				secrets_mb    = 64
 
 				devices {
 					name  = "fpga"
@@ -447,13 +445,11 @@ func testResourceQuotaSpecification_allFieldsCheck(name string) resource.TestChe
 		cores := 4
 		mem := 2048
 		memMax := 4096
-		secretsMB := 512
 		devCount := uint64(2)
 		nodePoolCPU := 800
 		nodePoolCores := 2
 		nodePoolMem := 1024
 		nodePoolMemMax := 2048
-		nodePoolSecrets := 64
 		nodePoolDevCount := uint64(1)
 		limits := []*api.QuotaLimit{
 			{
@@ -463,7 +459,6 @@ func testResourceQuotaSpecification_allFieldsCheck(name string) resource.TestChe
 					Cores:       &cores,
 					MemoryMB:    &mem,
 					MemoryMaxMB: &memMax,
-					SecretsMB:   &secretsMB,
 					Devices: []*api.RequestedDevice{
 						{
 							Name:  "gpu",
@@ -481,7 +476,6 @@ func testResourceQuotaSpecification_allFieldsCheck(name string) resource.TestChe
 							Cores:       &nodePoolCores,
 							MemoryMB:    &nodePoolMem,
 							MemoryMaxMB: &nodePoolMemMax,
-							SecretsMB:   &nodePoolSecrets,
 							Devices: []*api.RequestedDevice{
 								{
 									Name:  "fpga",
@@ -551,9 +545,6 @@ func testResourceQuotaSpecification_allFieldsCheck(name string) resource.TestChe
 		if *rl.MemoryMaxMB != *el.MemoryMaxMB {
 			return fmt.Errorf("expected MemoryMaxMB to be %d, got %d", *el.MemoryMaxMB, *rl.MemoryMaxMB)
 		}
-		if *rl.SecretsMB != *el.SecretsMB {
-			return fmt.Errorf("expected SecretsMB to be %d, got %d", *el.SecretsMB, *rl.SecretsMB)
-		}
 		if len(rl.Devices) != len(el.Devices) {
 			return fmt.Errorf("expected %d devices, got %d", len(el.Devices), len(rl.Devices))
 		}
@@ -589,9 +580,6 @@ func testResourceQuotaSpecification_allFieldsCheck(name string) resource.TestChe
 		}
 		if *rl.NodePools[0].MemoryMaxMB != *el.NodePools[0].MemoryMaxMB {
 			return fmt.Errorf("expected node_pool MemoryMaxMB to be %d, got %d", *el.NodePools[0].MemoryMaxMB, *rl.NodePools[0].MemoryMaxMB)
-		}
-		if *rl.NodePools[0].SecretsMB != *el.NodePools[0].SecretsMB {
-			return fmt.Errorf("expected node_pool SecretsMB to be %d, got %d", *el.NodePools[0].SecretsMB, *rl.NodePools[0].SecretsMB)
 		}
 		if len(rl.NodePools[0].Devices) != len(el.NodePools[0].Devices) {
 			return fmt.Errorf("expected %d node_pool devices, got %d", len(el.NodePools[0].Devices), len(rl.NodePools[0].Devices))

--- a/website/docs/r/quota_specification.html.markdown
+++ b/website/docs/r/quota_specification.html.markdown
@@ -27,7 +27,6 @@ resource "nomad_quota_specification" "prod_api" {
       cores        = 4
       memory_mb    = 1200
       memory_max_mb = 2400
-      secrets_mb   = 100
 
       devices {
         name  = "nvidia/gpu"
@@ -40,7 +39,6 @@ resource "nomad_quota_specification" "prod_api" {
         cores         = 2
         memory_mb     = 1024
         memory_max_mb = 2048
-        secrets_mb    = 64
 
         devices {
           name  = "fpga"
@@ -97,9 +95,6 @@ It supports the following arguments:
 - `memory_max_mb` `(int: 0)` - The maximum amount of memory (in megabytes) to
   limit allocations to. A value of zero is treated as unlimited, and a negative
   value is treated as fully disallowed.
-- `secrets_mb` `(int: 0)` - The amount of secrets storage (in megabytes) to
-  limit allocations to. A value of zero is treated as unlimited, and a negative
-  value is treated as fully disallowed.
 - [`devices`](#devices-blocks) `(block: optional)` - A list of device quotas to enforce. Can be
   repeated. See below for the structure of this block.
 - [`node_pools`](#node_pools-blocks) `(block: optional)` - Per-node-pool quota limits. Can be
@@ -141,9 +136,6 @@ following arguments:
   allocations to. A value of zero is treated as unlimited, and a negative value
   is treated as fully disallowed.
 - `memory_max_mb` `(int: 0)` - The maximum amount of memory (in megabytes) to
-  limit allocations to. A value of zero is treated as unlimited, and a negative
-  value is treated as fully disallowed.
-- `secrets_mb` `(int: 0)` - The amount of secrets storage (in megabytes) to
   limit allocations to. A value of zero is treated as unlimited, and a negative
   value is treated as fully disallowed.
 - [`devices`](#devices-blocks) `(block: optional)` - A list of device quotas to


### PR DESCRIPTION
secretsMB should not be set as it's only part of the Quota object because of previous struct sharing.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

