### PR TITLE
add ephemeral nomad_variable and write-only variable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS:
 * provider: add a muxed framework provider alongside the existing SDKv2 provider ([#594](https://github.com/hashicorp/terraform-provider-nomad/pull/594))
 * **New Ephemeral Resource**: `nomad_node_intro_token` creates a temporary Nomad client introduction token ([#595](https://github.com/hashicorp/terraform-provider-nomad/pull/595))
 * **New Ephemeral Resource**: `nomad_acl_token` reads a temporary Nomad ACL token without storing its secret in Terraform state ([#596](https://github.com/hashicorp/terraform-provider-nomad/pull/596))
+* **New Ephemeral Resource**: `nomad_variable` reads a Nomad variable during a Terraform run without storing its items in state ([#598](https://github.com/hashicorp/terraform-provider-nomad/pull/598))
 * data source/nomad_jwks: add EdDSA (Ed25519) key support ([#583](https://github.com/hashicorp/terraform-provider-nomad/pull/583))
 * data source/nomad_job_parser: add `variables` parameter to pass HCL2 variables to the job parser ([#582](https://github.com/hashicorp/terraform-provider-nomad/pull/582))
 * resource/nomad_acl_policy: make `job_id` optional in `job_acl` block to allow policies that apply to all jobs in a namespace ([#580](https://github.com/hashicorp/terraform-provider-nomad/pull/580))

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/acl"
+	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/variables"
 )
 
 // Ensure NomadProvider satisfies various provider interfaces.
@@ -148,5 +149,6 @@ func (p *NomadProvider) EphemeralResources(_ context.Context) []func() ephemeral
 	return []func() ephemeral.EphemeralResource{
 		acl.NewIntroTokenEphemeralResource,
 		acl.NewACLTokenEphemeralResource,
+		variables.NewVariableEphemeralResource,
 	}
 }

--- a/internal/framework/provider/variables/ephemeral_variable.go
+++ b/internal/framework/provider/variables/ephemeral_variable.go
@@ -1,0 +1,152 @@
+// Copyright IBM Corp. 2016, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package variables
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephemeralschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-nomad/nomad"
+)
+
+var _ ephemeral.EphemeralResource = &VariableEphemeralResource{}
+var _ ephemeral.EphemeralResourceWithConfigure = &VariableEphemeralResource{}
+
+type VariableEphemeralResource struct {
+	SDKv2Meta func() any
+}
+
+type variableEphemeralModel struct {
+	Path      types.String `tfsdk:"path"`
+	Namespace types.String `tfsdk:"namespace"`
+	Items     types.Map    `tfsdk:"items"`
+}
+
+func NewVariableEphemeralResource() ephemeral.EphemeralResource {
+	return &VariableEphemeralResource{}
+}
+
+func (r *VariableEphemeralResource) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_variable"
+}
+
+func (r *VariableEphemeralResource) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = ephemeralschema.Schema{
+		Description: "Reads a Nomad variable when its items are needed by Terraform but should not be stored in state.",
+		Attributes: map[string]ephemeralschema.Attribute{
+			"path": ephemeralschema.StringAttribute{
+				Required:    true,
+				Description: "The path of the variable.",
+			},
+			"namespace": ephemeralschema.StringAttribute{
+				Optional:    true,
+				Description: "Variable namespace. Defaults to default.",
+			},
+			"items": ephemeralschema.MapAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				ElementType: types.StringType,
+				Description: "A map of values from the stored variable.",
+			},
+		},
+	}
+}
+
+func (r *VariableEphemeralResource) Configure(_ context.Context, req ephemeral.ConfigureRequest, resp *ephemeral.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	sdkv2Meta, ok := req.ProviderData.(func() any)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Ephemeral Resource Configure Type",
+			fmt.Sprintf("Expected provider data of type func() any, got %T.", req.ProviderData),
+		)
+		return
+	}
+
+	r.SDKv2Meta = sdkv2Meta
+}
+
+func (r *VariableEphemeralResource) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var config variableEphemeralModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		log.Printf("[DEBUG] nomad_variable: config decoding returned diagnostics")
+		return
+	}
+
+	if r.SDKv2Meta == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured Nomad Provider",
+			"The provider has not been configured. Configure the nomad provider before using nomad_variable.",
+		)
+		return
+	}
+
+	providerData := r.SDKv2Meta()
+	providerConfig, ok := providerData.(nomad.ProviderConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider Metadata Type",
+			fmt.Sprintf("Expected nomad.ProviderConfig, got %T.", providerData),
+		)
+		return
+	}
+
+	client := providerConfig.Client()
+	if client == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured Nomad Client",
+			"The provider did not expose a configured Nomad API client.",
+		)
+		return
+	}
+
+	path := config.Path.ValueString()
+	namespace := api.DefaultNamespace
+	if !config.Namespace.IsNull() && !config.Namespace.IsUnknown() && config.Namespace.ValueString() != "" {
+		namespace = config.Namespace.ValueString()
+	}
+
+	log.Printf("[DEBUG] nomad_variable: reading variable %q in namespace %q", path, namespace)
+	variable, _, err := client.Variables().Read(path, &api.QueryOptions{Namespace: namespace})
+	if err != nil {
+		if strings.Contains(err.Error(), "404") || errors.Is(err, api.ErrVariablePathNotFound) {
+			resp.Diagnostics.AddError("Variable not found", fmt.Sprintf("No variable found for path %q in namespace %q.", path, namespace))
+			return
+		}
+
+		resp.Diagnostics.AddError("Error reading variable", err.Error())
+		return
+	}
+	log.Printf("[DEBUG] nomad_variable: successfully read variable %q in namespace %q", path, namespace)
+
+	result, diags := buildVariableResult(ctx, variable)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &result)...)
+}
+
+func buildVariableResult(ctx context.Context, variable *api.Variable) (variableEphemeralModel, diag.Diagnostics) {
+	items, diags := types.MapValueFrom(ctx, types.StringType, variable.Items)
+
+	return variableEphemeralModel{
+		Path:      types.StringValue(variable.Path),
+		Namespace: types.StringValue(variable.Namespace),
+		Items:     items,
+	}, diags
+}

--- a/internal/framework/provider/variables/ephemeral_variable_test.go
+++ b/internal/framework/provider/variables/ephemeral_variable_test.go
@@ -1,0 +1,143 @@
+// Copyright IBM Corp. 2017, 2026
+
+package variables_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	sdkv2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider"
+	"github.com/hashicorp/terraform-provider-nomad/nomad"
+)
+
+func TestAccEphemeralVariable_basic(t *testing.T) {
+	path := fmt.Sprintf("acctest-variable-%d", time.Now().UnixNano())
+	createTestVariable(t, path, api.DefaultNamespace)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEphemeralVariableConfig(path, api.DefaultNamespace),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"echo.test",
+						tfjsonpath.New("data").AtMapKey("path"),
+						knownvalue.StringExact(path),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.test",
+						tfjsonpath.New("data").AtMapKey("namespace"),
+						knownvalue.StringExact(api.DefaultNamespace),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.test",
+						tfjsonpath.New("data").AtMapKey("items").AtMapKey("test_key"),
+						knownvalue.StringExact("test_value"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccEphemeralVariableConfig(path, namespace string) string {
+	return fmt.Sprintf(`
+provider "nomad" {}
+
+ephemeral "nomad_variable" "test" {
+  path      = %q
+  namespace = %q
+}
+
+provider "echo" {
+  data = ephemeral.nomad_variable.test
+}
+
+resource "echo" "test" {}
+`, path, namespace)
+}
+
+func createTestVariable(t *testing.T, path, namespace string) {
+	t.Helper()
+
+	providerData := sdkv2providerMeta(t)()
+	providerConfig, ok := providerData.(nomad.ProviderConfig)
+	if !ok {
+		t.Fatalf("expected nomad.ProviderConfig, got %T", providerData)
+	}
+
+	variable := &api.Variable{
+		Namespace: namespace,
+		Path:      path,
+		Items: map[string]string{
+			"test_key": "test_value",
+		},
+	}
+
+	if _, _, err := providerConfig.Client().Variables().Create(variable, nil); err != nil {
+		t.Fatalf("failed to create test variable: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if _, err := providerConfig.Client().Variables().Delete(path, &api.WriteOptions{Namespace: namespace}); err != nil {
+			t.Logf("failed to delete test variable %q@%q: %v", path, namespace, err)
+		}
+	})
+}
+
+func sdkv2providerMeta(t *testing.T) func() any {
+	t.Helper()
+
+	p := nomad.Provider()
+	if err := p.Configure(context.Background(), sdkv2.NewResourceConfigRaw(nil)); err != nil {
+		t.Fatalf("failed to configure sdkv2 provider: %v", err)
+	}
+
+	return p.Meta
+}
+
+func testAccProtoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
+	return map[string]func() (tfprotov6.ProviderServer, error){
+		"nomad": func() (tfprotov6.ProviderServer, error) {
+			return providerserver.NewProtocol6WithError(provider.New(sdkv2providerMetaForFactory()))()
+		},
+		"echo": echoprovider.NewProviderServer(),
+	}
+}
+
+func sdkv2providerMetaForFactory() func() any {
+	p := nomad.Provider()
+	if err := p.Configure(context.Background(), sdkv2.NewResourceConfigRaw(nil)); err != nil {
+		panic(fmt.Sprintf("failed to configure sdkv2 provider: %v", err))
+	}
+
+	return p.Meta
+}
+
+func testAccPreCheck(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv("NOMAD_ADDR") == "" {
+		os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	}
+
+	_ = sdkv2providerMeta(t)
+}

--- a/internal/framework/provider/variables/ephemeral_variable_test.go
+++ b/internal/framework/provider/variables/ephemeral_variable_test.go
@@ -3,23 +3,17 @@
 package variables_test
 
 import (
-	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	sdkv2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider"
+	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/testutil"
 	"github.com/hashicorp/terraform-provider-nomad/nomad"
 )
 
@@ -28,8 +22,8 @@ func TestAccEphemeralVariable_basic(t *testing.T) {
 	createTestVariable(t, path, api.DefaultNamespace)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories(),
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_10_0),
 		},
@@ -78,7 +72,7 @@ resource "echo" "test" {}
 func createTestVariable(t *testing.T, path, namespace string) {
 	t.Helper()
 
-	providerData := sdkv2providerMeta(t)()
+	providerData := testutil.SDKV2ProviderMeta(t)()
 	providerConfig, ok := providerData.(nomad.ProviderConfig)
 	if !ok {
 		t.Fatalf("expected nomad.ProviderConfig, got %T", providerData)
@@ -101,43 +95,4 @@ func createTestVariable(t *testing.T, path, namespace string) {
 			t.Logf("failed to delete test variable %q@%q: %v", path, namespace, err)
 		}
 	})
-}
-
-func sdkv2providerMeta(t *testing.T) func() any {
-	t.Helper()
-
-	p := nomad.Provider()
-	if err := p.Configure(context.Background(), sdkv2.NewResourceConfigRaw(nil)); err != nil {
-		t.Fatalf("failed to configure sdkv2 provider: %v", err)
-	}
-
-	return p.Meta
-}
-
-func testAccProtoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
-	return map[string]func() (tfprotov6.ProviderServer, error){
-		"nomad": func() (tfprotov6.ProviderServer, error) {
-			return providerserver.NewProtocol6WithError(provider.New(sdkv2providerMetaForFactory()))()
-		},
-		"echo": echoprovider.NewProviderServer(),
-	}
-}
-
-func sdkv2providerMetaForFactory() func() any {
-	p := nomad.Provider()
-	if err := p.Configure(context.Background(), sdkv2.NewResourceConfigRaw(nil)); err != nil {
-		panic(fmt.Sprintf("failed to configure sdkv2 provider: %v", err))
-	}
-
-	return p.Meta
-}
-
-func testAccPreCheck(t *testing.T) {
-	t.Helper()
-
-	if os.Getenv("NOMAD_ADDR") == "" {
-		os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
-	}
-
-	_ = sdkv2providerMeta(t)
 }

--- a/nomad/data_source_variable.go
+++ b/nomad/data_source_variable.go
@@ -10,7 +10,8 @@ import (
 
 func dataSourceVariable() *schema.Resource {
 	return &schema.Resource{
-		Read: resourceVariableRead,
+		Read:               resourceVariableRead,
+		DeprecationMessage: "Use the nomad_variable ephemeral resource to read variable items without storing them in Terraform state. This data source will be removed in a future release.",
 
 		Schema: map[string]*schema.Schema{
 			"path": {

--- a/nomad/resource_variable.go
+++ b/nomad/resource_variable.go
@@ -92,9 +92,17 @@ func resourceVariableWrite(d *schema.ResourceData, meta any) error {
 
 	if rawItems, ok := d.GetOk("items"); ok {
 		variable.Items = expandVariableItems(rawItems.(map[string]any))
-	} else if _, ok := d.GetOk("items_wo"); ok {
+	} else if d.IsNewResource() || d.HasChange("items_wo_version") {
+		rawItems, diags := d.GetRawConfigAt(cty.GetAttrPath("items_wo"))
+		if diags.HasError() {
+			return fmt.Errorf("error reading items_wo config: %v", diags)
+		}
+		if rawItems.IsNull() || !rawItems.IsKnown() {
+			return fmt.Errorf("items_wo must be provided when items_wo_version is set")
+		}
+
 		items := map[string]string{}
-		if err := json.Unmarshal([]byte(d.Get("items_wo").(string)), &items); err != nil {
+		if err := json.Unmarshal([]byte(rawItems.AsString()), &items); err != nil {
 			return fmt.Errorf("error decoding items_wo: %w", err)
 		}
 		variable.Items = items

--- a/nomad/resource_variable.go
+++ b/nomad/resource_variable.go
@@ -4,6 +4,7 @@
 package nomad
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const (
@@ -54,10 +56,27 @@ func resourceVariable() *schema.Resource {
 				Default:     api.DefaultNamespace,
 			},
 			"items": {
-				Description: "A map of strings to be added as items in the variable",
-				Type:        schema.TypeMap,
-				Required:    true,
-				Sensitive:   true,
+				Description:  "A map of strings to be added as items in the variable",
+				Type:         schema.TypeMap,
+				Optional:     true,
+				Sensitive:    true,
+				ExactlyOneOf: []string{"items", "items_wo"},
+			},
+			"items_wo": {
+				Description:  "JSON-encoded variable items to write without storing them in Terraform state.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				WriteOnly:    true,
+				ExactlyOneOf: []string{"items", "items_wo"},
+			},
+			"items_wo_version": {
+				Description:   "Version marker for items_wo updates. Increment this value to apply a new write-only variable payload.",
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ConflictsWith: []string{"items"},
+				RequiredWith:  []string{"items_wo"},
+				ValidateFunc:  validation.IntAtLeast(1),
 			},
 		},
 	}
@@ -69,11 +88,16 @@ func resourceVariableWrite(d *schema.ResourceData, meta any) error {
 	variable := &api.Variable{
 		Namespace: d.Get("namespace").(string),
 		Path:      d.Get("path").(string),
-		Items:     make(map[string]string),
 	}
 
-	for name, value := range d.Get("items").(map[string]any) {
-		variable.Items[name] = value.(string)
+	if rawItems, ok := d.GetOk("items"); ok {
+		variable.Items = expandVariableItems(rawItems.(map[string]any))
+	} else if _, ok := d.GetOk("items_wo"); ok {
+		items := map[string]string{}
+		if err := json.Unmarshal([]byte(d.Get("items_wo").(string)), &items); err != nil {
+			return fmt.Errorf("error decoding items_wo: %w", err)
+		}
+		variable.Items = items
 	}
 
 	log.Printf("[DEBUG] Upserting variable %s@%s", variable.Path, variable.Namespace)
@@ -119,6 +143,11 @@ func resourceVariableRead(d *schema.ResourceData, meta any) error {
 	}
 
 	d.SetId(variableID)
+
+	if d.Get("items_wo_version").(int) > 0 {
+		return d.Set("items", nil)
+	}
+
 	return d.Set("items", variable.Items)
 }
 
@@ -140,6 +169,15 @@ func resourceVariableExists(d *schema.ResourceData, meta any) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func expandVariableItems(rawItems map[string]any) map[string]string {
+	items := make(map[string]string, len(rawItems))
+	for name, value := range rawItems {
+		items[name] = value.(string)
+	}
+
+	return items
 }
 
 func pathValidation() schema.SchemaValidateDiagFunc {

--- a/nomad/resource_variable_test.go
+++ b/nomad/resource_variable_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestResourceVariable_basic(t *testing.T) {
@@ -79,6 +80,30 @@ func TestResourceVariable_namespaceChange(t *testing.T) {
 	})
 }
 
+func TestResourceVariable_writeOnlyItems(t *testing.T) {
+	path := acctest.RandomWithPrefix("tf-nomad-test")
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.4.0") },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_11_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceVariable_writeOnlyConfig(api.DefaultNamespace, path, 1, "test_value"),
+				Check:  testResourceVariable_writeOnlyCheck(api.DefaultNamespace, path, "test_value"),
+			},
+			{
+				Config: testResourceVariable_writeOnlyConfig(api.DefaultNamespace, path, 2, "updated_value"),
+				Check:  testResourceVariable_writeOnlyCheck(api.DefaultNamespace, path, "updated_value"),
+			},
+		},
+
+		CheckDestroy: testResourceVariable_checkDestroy(api.DefaultNamespace, path),
+	})
+}
+
 func testResourceVariable_initialConfig(namespace, path string) string {
 	return fmt.Sprintf(`
 resource "nomad_variable" "test" {
@@ -99,6 +124,21 @@ resource nomad_namespace "nomad_var_test" {
 }
 %s
 `, namespace, testResourceVariable_initialConfig("${nomad_namespace.nomad_var_test.name}", path))
+}
+
+func testResourceVariable_writeOnlyConfig(namespace, path string, version int, value string) string {
+	return fmt.Sprintf(`
+resource "nomad_variable" "test" {
+	namespace = %q
+	path      = %q
+
+	items_wo = jsonencode({
+	  test_key = %q
+	})
+
+	items_wo_version = %d
+}
+`, namespace, path, value, version)
 }
 
 func testResourceVariable_initialCheck(namespace, path string) resource.TestCheckFunc {
@@ -156,5 +196,37 @@ func testResourceVariable_checkDestroy(namespace, path string) resource.TestChec
 		}
 
 		return fmt.Errorf("variable %q has not been deleted.", resourceID)
+	}
+}
+
+func testResourceVariable_writeOnlyCheck(namespace, path, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if err := testResourceVariable_initialCheck(namespace, path)(s); err != nil {
+			return err
+		}
+
+		resourceState := s.Modules[0].Resources["nomad_variable.test"]
+		if resourceState == nil || resourceState.Primary == nil {
+			return errors.New("resource has no primary instance")
+		}
+
+		instanceState := resourceState.Primary
+		if storedValue, ok := instanceState.Attributes["items.test_key"]; ok && storedValue != "" {
+			return fmt.Errorf("expected write-only items not to be stored in state, found value %q", storedValue)
+		}
+		if itemCount, ok := instanceState.Attributes["items.%"]; ok && itemCount != "" && itemCount != "0" {
+			return fmt.Errorf("expected no persisted items in state for write-only variable, found items.%%=%q", itemCount)
+		}
+
+		client := testProvider.Meta().(ProviderConfig).client
+		variable, _, err := client.Variables().Read(path, &api.QueryOptions{Namespace: namespace})
+		if err != nil {
+			return fmt.Errorf("error reading back variable %q: %s", path+"@"+namespace, err)
+		}
+		if got := variable.Items["test_key"]; got != value {
+			return fmt.Errorf("expected variable item test_key to be %q, got %q", value, got)
+		}
+
+		return nil
 	}
 }

--- a/website/docs/d/variable.html.markdown
+++ b/website/docs/d/variable.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 Get the information about a Nomad variable.
 
+-> **Deprecated:** Use the `nomad_variable` ephemeral resource instead when you
+need to read variable items without storing them in Terraform state. This data
+source will be removed in a future release.
+
 ~> **Warning:** this data source will store the sensitive values from `items`
   in the Terraform's state file. Take care to
   [protect your state file](/docs/state/sensitive-data.html).

--- a/website/docs/ephemeral-resources/variable.html.markdown
+++ b/website/docs/ephemeral-resources/variable.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_variable"
+sidebar_current: "docs-nomad-ephemeral-resource-variable"
+description: |-
+  Reads a Nomad variable without storing its items in Terraform state.
+---
+
+# nomad_variable
+
+Reads a Nomad variable during a Terraform run without storing its items in
+state.
+
+Use the stateful `nomad_variable` resource to manage the variable lifecycle.
+Use this ephemeral resource whenever variable items need to be read during a
+run. Values returned by this resource are never persisted in state.
+
+## Example Usage
+
+```hcl
+resource "nomad_variable" "example" {
+  path = "some/path/of/your/choosing"
+
+  items_wo = jsonencode({
+    example_key = "example_value"
+  })
+
+  items_wo_version = 1
+}
+
+ephemeral "nomad_variable" "example" {
+  path = nomad_variable.example.path
+}
+
+resource "some_resource" "example" {
+  secret_value_wo         = ephemeral.nomad_variable.example.items.example_key
+  secret_value_wo_version = 1
+}
+```
+
+## Argument Reference
+
+- `path` `(string: <required>)` - The path of the variable.
+- `namespace` `(string: "default")` - The namespace in which the variable exists.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- `path` `(string)` - The path at which the variable exists.
+- `namespace` `(string)` - The namespace in which the variable exists.
+- `items` `(map[string]string)` - Map of items in the variable.

--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -15,6 +15,9 @@ Nomad cluster.
   `items` in the Terraform's state file. Take care to
   [protect your state file](/docs/state/sensitive-data.html).
 
+~> **Note:** Use `items_wo` with `items_wo_version` when you want Terraform to
+  write variable items without storing those values in the state file.
+
 ## Example Usage
 
 Creating a variable in the default namespace:
@@ -25,6 +28,20 @@ resource "nomad_variable" "example" {
   items = {
     example_key = "example_value"
   }
+}
+```
+
+Creating a variable with write-only items:
+
+```hcl
+resource "nomad_variable" "example" {
+  path = "some/path/of/your/choosing"
+
+  items_wo = jsonencode({
+    example_key = "example_value"
+  })
+
+  items_wo_version = 1
 }
 ```
 
@@ -49,4 +66,6 @@ resource "nomad_variable" "example" {
 
 - `path` `(string: <required>)` - A unique path to create the variable at.
 - `namespace` `(string: "default")` - The namepsace to create the variable in.
-- `items` `(map[string]string: <required>)` - An arbitrary map of items to create in the variable.
+- `items` `(map[string]string)` - An arbitrary map of items to create in the variable. Conflicts with `items_wo`.
+- `items_wo` `(string)` - A JSON-encoded map of variable items to write without storing those values in Terraform state. Conflicts with `items`.
+- `items_wo_version` `(number)` - A version marker for `items_wo`. Increment this value to apply a new write-only payload.

--- a/website/nomad.erb
+++ b/website/nomad.erb
@@ -67,6 +67,9 @@
             <li<%= sidebar_current("docs-nomad-datasource-scheduler-config") %>>
               <a href="/docs/providers/nomad/d/scheduler_config.html">nomad_scheduler_config</a>
             </li>
+            <li<%= sidebar_current("docs-nomad-datasource-variable") %>>
+              <a href="/docs/providers/nomad/d/variable.html">nomad_variable</a>
+            </li>
             <li<%= sidebar_current("docs-nomad-datasource-volumes") %>>
               <a href="/docs/providers/nomad/d/volumes.html">nomad_volumes</a>
             </li>
@@ -110,19 +113,26 @@
             <li<%= sidebar_current("docs-nomad-resource-scheduler-config") %>>
               <a href="/docs/providers/nomad/r/scheduler_config.html">nomad_scheduler_config</a>
             </li>
+            <li<%= sidebar_current("docs-nomad-resource-variable") %>>
+              <a href="/docs/providers/nomad/r/variable.html">nomad_variable</a>
+            </li>
             <li<%= sidebar_current("docs-nomad-resource-volume") %>>
               <a href="/docs/providers/nomad/r/volume.html">nomad_volume</a>
             </li>
           </ul>
         </li>
 
-        <li<%= sidebar_current("docs-nomad-ephemeral") %>>
+        <li<%= sidebar_current("docs-nomad-ephemeral-resource") %>>
           <a href="#">Ephemeral Resources</a>
           <ul class="nav nav-visible">
             <li<%= sidebar_current("docs-nomad-ephemeral-node-intro-token") %>>
               <a href="/docs/providers/nomad/ephemeral-resources/node_intro_token.html">nomad_node_intro_token</a>
+            </li>
             <li<%= sidebar_current("docs-nomad-ephemeral-acl-token") %>>
               <a href="/docs/providers/nomad/ephemeral-resources/acl_token.html">nomad_acl_token</a>
+            </li>
+            <li<%= sidebar_current("docs-nomad-ephemeral-resource-variable") %>>
+              <a href="/docs/providers/nomad/ephemeral-resources/variable.html">nomad_variable</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Adds support for reading Nomad variables through a new ephemeral `nomad_variable` resource and deprecates the existing `nomad_variable` data source. This also adds write-only variable item support to the managed `nomad_variable` resource so sensitive values can be written without being stored in Terraform state.

## Changes

- add ephemeral `nomad_variable` resource implemented in the framework provider
- deprecate the `nomad_variable` data source in favor of the ephemeral resource
- add `items_wo` and `items_wo_version` to the `nomad_variable` resource for write-only variable updates
- add acceptance coverage for ephemeral variable reads and write-only variable updates
- update docs and changelog for the new ephemeral resource and data source deprecation

## Behavior

- use `resource "nomad_variable"` to manage variable lifecycle
- use `ephemeral "nomad_variable"` to read variable items during a Terraform run
- values read through the ephemeral resource are not persisted in state
- values written through `items_wo` are not persisted in state
- updating write-only values requires incrementing `items_wo_version`

[JIRA Ticket](https://hashicorp.atlassian.net/browse/NMD-1340)

### Testing & Reproduction steps

<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
#### Acceptance Tests

```bash
TF_ACC=1 go test ./internal/framework/provider/variables -run '^TestAccEphemeralVariable_basic$' -count=1
```

#### Local validation

Prerequisites:

- a running Nomad cluster
- NOMAD_ADDR set to the target cluster
- NOMAD_TOKEN set if the target cluster requires ACL authentication
- Terraform >= 1.10

Example configuration:
```bash
terraform {
  required_providers {
    nomad = {
      source = "hashicorp/nomad"
    }
  }
}

provider "nomad" {}

resource "nomad_variable" "write_only" {
  namespace = var.namespace
  path      = var.variable_path

  items_wo = jsonencode({
    test_key   = var.variable_value
    second_key = var.secondary_value
  })

  items_wo_version = var.variable_version
}

locals {
  write_only_variable_id_parts = split("@", nomad_variable.write_only.id)
}

ephemeral "nomad_variable" "write_only" {
  path      = local.write_only_variable_id_parts[0]
  namespace = local.write_only_variable_id_parts[1]
}

resource "terraform_data" "ephemeral_summary_file" {
  triggers_replace = [
    nomad_variable.write_only.id,
    tostring(var.variable_version),
  ]

  provisioner "local-exec" {
    command = <<-EOT
      cat > "$SUMMARY_FILE" <<EOF
      {
        "namespace": "$NAMESPACE",
        "path": "$VARIABLE_PATH",
        "item_keys": $ITEM_KEYS,
        "items": $ITEMS,
        "values_match_inputs": $VALUES_MATCH_INPUTS
      }
      EOF
    EOT

    environment = {
      SUMMARY_FILE  = "${path.module}/ephemeral_variable_summary.json"
      NAMESPACE     = ephemeral.nomad_variable.write_only.namespace
      VARIABLE_PATH = ephemeral.nomad_variable.write_only.path
      ITEM_KEYS     = jsonencode(sort(keys(nonsensitive(ephemeral.nomad_variable.write_only.items))))
      ITEMS         = jsonencode(nonsensitive(ephemeral.nomad_variable.write_only.items))
      VALUES_MATCH_INPUTS = jsonencode(
        try(ephemeral.nomad_variable.write_only.items.test_key, null) == var.variable_value &&
        try(ephemeral.nomad_variable.write_only.items.second_key, null) == var.secondary_value
      )
    }
  }
}
```

1. Run  ```terraform init```
2. Run ```terraform apply```
4. Confirm the ephemeral read succeeds for the variable created through `nomad_variable.write_only`
5. Verify ephemeral_variable_summary.json contains the expected namespace, path, and item values
6. Verify the managed `nomad_variable` state does not expose the write-only payload

```
❯ terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/nomad in /Users/vishnuu/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.terraform_remote_state.bootstrap: Reading...
data.terraform_remote_state.bootstrap: Read complete after 0s
ephemeral.nomad_variable.write_only: Configuration unknown, deferring...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # nomad_variable.write_only will be created
  + resource "nomad_variable" "write_only" {
      + id               = (known after apply)
      + items_wo         = (write-only attribute)
      + items_wo_version = 1
      + namespace        = "default"
      + path             = "pr-598/write-only-variable"
    }

  # terraform_data.ephemeral_summary_file will be created
  + resource "terraform_data" "ephemeral_summary_file" {
      + id               = (known after apply)
      + triggers_replace = [
          + (known after apply),
          + "1",
        ]
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + ephemeral_summary_file_path  = "./ephemeral_variable_summary.json"
  + write_only_variable_metadata = {
      + id               = (known after apply)
      + items_wo_version = 1
      + namespace        = "default"
      + path             = "pr-598/write-only-variable"
    }
╷
│ Warning: Check block assertion known after apply
│ 
│   on main.tf line 57, in check "write_only_variable_round_trip":
│   57:     condition     = try(ephemeral.nomad_variable.write_only.items.test_key, null) == var.variable_value
│ 
│ The condition could not be evaluated at this time, a result will be known when this plan is applied.
╵
╷
│ Warning: Check block assertion known after apply
│ 
│   on main.tf line 62, in check "write_only_variable_round_trip":
│   62:     condition     = try(ephemeral.nomad_variable.write_only.items.second_key, null) == var.secondary_value
│ 
│ The condition could not be evaluated at this time, a result will be known when this plan is applied.
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

nomad_variable.write_only: Creating...
nomad_variable.write_only: Creation complete after 0s [id=pr-598/write-only-variable@default]
ephemeral.nomad_variable.write_only: Opening...
ephemeral.nomad_variable.write_only: Opening complete after 0s
terraform_data.ephemeral_summary_file: Creating...
terraform_data.ephemeral_summary_file: Provisioning with 'local-exec'...
terraform_data.ephemeral_summary_file (local-exec): (output suppressed due to sensitive, ephemeral value in config)
terraform_data.ephemeral_summary_file: Creation complete after 0s [id=351e2d16-3f0c-b8fd-c0f7-e03bb67e7fcb]
ephemeral.nomad_variable.write_only: Closing...
ephemeral.nomad_variable.write_only: Closing complete after 0s

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

ephemeral_summary_file_path = "./ephemeral_variable_summary.json"
write_only_variable_metadata = {
  "id" = "pr-598/write-only-variable@default"
  "items_wo_version" = 1
  "namespace" = "default"
  "path" = "pr-598/write-only-variable"
}
```

```
❯ cat ephemeral_variable_summary.json
{
  "namespace": "default",
  "path": "pr-598/write-only-variable",
  "item_keys": ["second_key","test_key"],
  "items": {"second_key":"second_value","test_key":"test_value"},
  "values_match_inputs": true
}
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

