### PR TITLE
resource/nomad_variable: require items_wo_version with items_wo

### DIFF
--- a/nomad/resource_variable.go
+++ b/nomad/resource_variable.go
@@ -63,19 +63,19 @@ func resourceVariable() *schema.Resource {
 				ExactlyOneOf: []string{"items", "items_wo"},
 			},
 			"items_wo": {
-				Description:  "JSON-encoded variable items to write without storing them in Terraform state.",
+				Description:  "JSON-encoded variable items to write without storing them in Terraform state. Requires items_wo_version.",
 				Type:         schema.TypeString,
 				Optional:     true,
 				Sensitive:    true,
 				WriteOnly:    true,
 				ExactlyOneOf: []string{"items", "items_wo"},
+				RequiredWith: []string{"items_wo_version"},
 			},
 			"items_wo_version": {
-				Description:   "Version marker for items_wo updates. Increment this value to apply a new write-only variable payload.",
+				Description:   "Version marker for items_wo updates. Required when using items_wo, and increment this value to apply a new write-only variable payload.",
 				Type:          schema.TypeInt,
 				Optional:      true,
 				ConflictsWith: []string{"items"},
-				RequiredWith:  []string{"items_wo"},
 				ValidateFunc:  validation.IntAtLeast(1),
 			},
 		},
@@ -98,7 +98,7 @@ func resourceVariableWrite(d *schema.ResourceData, meta any) error {
 			return fmt.Errorf("error reading items_wo config: %v", diags)
 		}
 		if rawItems.IsNull() || !rawItems.IsKnown() {
-			return fmt.Errorf("items_wo must be provided when items_wo_version is set")
+			return fmt.Errorf("items_wo must be provided when using items_wo_version")
 		}
 
 		items := map[string]string{}

--- a/nomad/resource_variable_test.go
+++ b/nomad/resource_variable_test.go
@@ -6,6 +6,7 @@ package nomad
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -104,6 +105,34 @@ func TestResourceVariable_writeOnlyItems(t *testing.T) {
 	})
 }
 
+func TestResourceVariable_writeOnlyItemsRequiresVersion(t *testing.T) {
+	path := acctest.RandomWithPrefix("tf-nomad-test")
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testResourceVariable_writeOnlyConfigWithoutVersion(api.DefaultNamespace, path, "test_value"),
+				ExpectError: regexp.MustCompile(`"items_wo": all of ` + "`items_wo,items_wo_version`" + ` must be specified`),
+			},
+		},
+	})
+}
+
+func TestResourceVariable_itemsConflictWithWriteOnlyVersion(t *testing.T) {
+	path := acctest.RandomWithPrefix("tf-nomad-test")
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testResourceVariable_itemsConfigWithWriteOnlyVersion(api.DefaultNamespace, path, 1),
+				ExpectError: regexp.MustCompile(`"items_wo_version": conflicts with items`),
+			},
+		},
+	})
+}
+
 func testResourceVariable_initialConfig(namespace, path string) string {
 	return fmt.Sprintf(`
 resource "nomad_variable" "test" {
@@ -115,6 +144,21 @@ resource "nomad_variable" "test" {
   }
 }
 `, namespace, path)
+}
+
+func testResourceVariable_itemsConfigWithWriteOnlyVersion(namespace, path string, version int) string {
+	return fmt.Sprintf(`
+resource "nomad_variable" "test" {
+	namespace = %q
+	path      = %q
+
+	items = {
+		test_key = "test_value"
+	}
+
+	items_wo_version = %d
+}
+`, namespace, path, version)
 }
 
 func testResourceVariable_initialConfigWithNamespace(namespace, path string) string {
@@ -139,6 +183,19 @@ resource "nomad_variable" "test" {
 	items_wo_version = %d
 }
 `, namespace, path, value, version)
+}
+
+func testResourceVariable_writeOnlyConfigWithoutVersion(namespace, path, value string) string {
+	return fmt.Sprintf(`
+resource "nomad_variable" "test" {
+	namespace = %q
+	path      = %q
+
+	items_wo = jsonencode({
+	  test_key = %q
+	})
+}
+`, namespace, path, value)
 }
 
 func testResourceVariable_initialCheck(namespace, path string) resource.TestCheckFunc {

--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -66,6 +66,6 @@ resource "nomad_variable" "example" {
 
 - `path` `(string: <required>)` - A unique path to create the variable at.
 - `namespace` `(string: "default")` - The namepsace to create the variable in.
-- `items` `(map[string]string)` - An arbitrary map of items to create in the variable. Conflicts with `items_wo`.
-- `items_wo` `(string)` - A JSON-encoded map of variable items to write without storing those values in Terraform state. Conflicts with `items`.
-- `items_wo_version` `(number)` - A version marker for `items_wo`. Increment this value to apply a new write-only payload.
+- `items` `(map[string]string)` - An arbitrary map of items to create in the variable. Conflicts with `items_wo` and `items_wo_version`.
+- `items_wo` `(string)` - A JSON-encoded map of variable items to write without storing those values in Terraform state. Conflicts with `items` and requires `items_wo_version`.
+- `items_wo_version` `(number)` - A version marker for `items_wo`. Required when using `items_wo`, conflicts with `items`, and should be incremented to apply a new write-only payload.


### PR DESCRIPTION
### Description

Previously, `items_wo_version` required `items_wo`, but `items_wo` could still be set without `items_wo_version`. That was inconsistent with how the resource actually applies write-only updates, since write-only payload changes are driven by `items_wo_version`.

This update makes the contract explicit and consistent:

- `items` and `items_wo` remain mutually exclusive
- `items_wo` now requires `items_wo_version`
- `items_wo_version` continues to conflict with `items`

The change also updates validation tests to cover the invalid combinations and clarifies the schema descriptions/runtime messaging for the write-only flow.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.
