### PR TITLE
update terraform registry protocol version

### DIFF
--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,6 +1,6 @@
 {
     "version": 1,
     "metadata": {
-        "protocol_versions": ["5.0"]
+        "protocol_versions": ["6.0"]
     }
 }


### PR DESCRIPTION
### Description

This PR updates the Terraform Registry manifest from protocol v5 to v6 to align with the provider’s current main and mux-based implementation. No functional provider behavior changes are intended beyond the protocol/version metadata update.

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.
