### PR TITLE
omit x5 suffix for the bin name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - name: Detect Go version
         id: get-go-version
         run: |
@@ -137,7 +137,7 @@ jobs:
           METADATA_VERSION: ${{ env.METADATA }}
         with:
           # Protocol v6 providers should omit the `_x5` suffix.
-          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_x5"
+          bin_name: "${{ env.PKG_NAME }}_v${{ needs.set-product-version.outputs.product-version }}"
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}
           go_version: ${{ needs.get-go-version.outputs.go-version }}


### PR DESCRIPTION
### Description

Omit's the _x5 suffix from the bin name due to protocol v6 provider



<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.
