### PR TITLE
fix mismatch in framework provider schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+BUG FIXES:
+* provider: fix muxed provider schema mismatch for `address` when provider configuration is used without `NOMAD_ADDR` in the environment ([#608](https://github.com/hashicorp/terraform-provider-nomad/pull/608))
+
 ## 2.6.0 (April 16, 2026)
 
 IMPROVEMENTS:

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -41,7 +41,7 @@ func (p *NomadProvider) Schema(_ context.Context, _ frameworkprovider.SchemaRequ
 	resp.Schema = providerschema.Schema{
 		Attributes: map[string]providerschema.Attribute{
 			"address": providerschema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Description: "URL of the root of the target Nomad agent.",
 			},
 			"region": providerschema.StringAttribute{

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -41,7 +41,7 @@ func (p *NomadProvider) Schema(_ context.Context, _ frameworkprovider.SchemaRequ
 	resp.Schema = providerschema.Schema{
 		Attributes: map[string]providerschema.Attribute{
 			"address": providerschema.StringAttribute{
-				Optional:    true,
+				Required:    true,
 				Description: "URL of the root of the target Nomad agent.",
 			},
 			"region": providerschema.StringAttribute{

--- a/internal/framework/provider/testutil/helpers.go
+++ b/internal/framework/provider/testutil/helpers.go
@@ -18,6 +18,7 @@ import (
 
 func SDKV2ProviderMeta(t *testing.T) func() any {
 	t.Helper()
+	ensureNomadAddrEnv()
 
 	p := nomad.Provider()
 	if err := p.Configure(context.Background(), sdkv2.NewResourceConfigRaw(nil)); err != nil {
@@ -38,19 +39,24 @@ func TestAccProtoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServ
 
 func TestAccPreCheck(t *testing.T) {
 	t.Helper()
-
-	if os.Getenv("NOMAD_ADDR") == "" {
-		os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
-	}
+	ensureNomadAddrEnv()
 
 	_ = SDKV2ProviderMeta(t)
 }
 
 func sdkv2ProviderMetaForFactory() func() any {
+	ensureNomadAddrEnv()
+
 	p := nomad.Provider()
 	if err := p.Configure(context.Background(), sdkv2.NewResourceConfigRaw(nil)); err != nil {
 		panic(fmt.Sprintf("failed to configure sdkv2 provider: %v", err))
 	}
 
 	return p.Meta
+}
+
+func ensureNomadAddrEnv() {
+	if os.Getenv("NOMAD_ADDR") == "" {
+		os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	}
 }

--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -26,8 +26,7 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"address": {
 				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NOMAD_ADDR", nil),
+				Optional:    true,
 				Description: "URL of the root of the target Nomad agent.",
 			},
 			"region": {
@@ -215,7 +214,13 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	conf := api.DefaultConfig()
-	conf.Address = d.Get("address").(string)
+	if address, ok := d.GetOk("address"); ok {
+		conf.Address = address.(string)
+	} else if address := os.Getenv("NOMAD_ADDR"); address != "" {
+		conf.Address = address
+	} else {
+		return nil, fmt.Errorf("address must be provided either in provider configuration or via NOMAD_ADDR")
+	}
 	conf.SecretID = d.Get("secret_id").(string)
 
 	if region, ok := d.GetOk("region"); ok {

--- a/nomad/provider_test.go
+++ b/nomad/provider_test.go
@@ -4,6 +4,7 @@
 package nomad
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -545,4 +546,33 @@ func testAccProviderFactoryInternal(provider **schema.Provider) map[string]func(
 		*provider = p
 	}
 	return factories
+}
+
+func TestProviderConfigure_AddressFromEnv(t *testing.T) {
+	t.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+
+	p := Provider()
+	err := p.Configure(context.Background(), sdkterraform.NewResourceConfigRaw(nil))
+	if err != nil {
+		t.Fatalf("unexpected configure error: %v", err)
+	}
+
+	providerConfig := p.Meta().(ProviderConfig)
+	if got, want := providerConfig.config.Address, "http://127.0.0.1:4646"; got != want {
+		t.Fatalf("expected address %q, got %q", want, got)
+	}
+}
+
+func TestProviderConfigure_AddressRequired(t *testing.T) {
+	t.Setenv("NOMAD_ADDR", "")
+
+	p := Provider()
+	diags := p.Configure(context.Background(), sdkterraform.NewResourceConfigRaw(nil))
+	if diags == nil || !diags.HasError() {
+		t.Fatal("expected configure error, got nil")
+	}
+
+	if !strings.Contains(diags[0].Summary, "address must be provided either in provider configuration or via NOMAD_ADDR") {
+		t.Fatalf("unexpected diagnostics: %#v", diags)
+	}
 }


### PR DESCRIPTION
The mux framework provider schema does not match the schema used in the top-level provider. This causes a fatal error on plugin startup.

Fixes: https://hashicorp.atlassian.net/browse/NMD-1391

### Testing & Reproduction steps

Note : Set address explicitly in the provider config without having `NOMAD_ADDR` environment variable set.

```
$ ls -lah
total 4.0K
drwxr-xr-x. 1 tim tim   14 Apr 16 16:14 ./
drwxr-xr-x. 1 tim tim  674 Apr  1 10:20 ../
-rw-r--r--. 1 tim tim 2.2K Apr  7  2025 main.tf

$ terraform init
Initializing the backend...
Initializing provider plugins...
- Finding latest version of hashicorp/nomad...
- Installing hashicorp/nomad v2.6.0...
- Installed hashicorp/nomad v2.6.0 (signed by HashiCorp)
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

$ terraform plan
╷
│ Error: Failed to load plugin schemas
│
│ Error while loading schemas for plugin components: Failed to obtain provider schema: Could not load
│ the schema for provider registry.terraform.io/hashicorp/nomad: failed to retrieve schema from
│ provider "registry.terraform.io/hashicorp/nomad": Invalid Provider Server Combination: The combined
│ provider has differing provider schema implementations across providers. Provider schemas must be
│ identical across providers. This is always an issue in the provider implementation and should be
│ reported to the provider developers.
│
│ Provider schema difference:   &tfprotov6.Schema{
│       Version: 0,
│       Block: &tfprotov6.SchemaBlock{
│               Version: 0,
│               Attributes: []*tfprotov6.SchemaAttribute{
│                       &{
│                               ... // 2 identical fields
│                               NestedType:  nil,
│                               Description: "URL of the root of the target Nomad agent.",
│ -                             Required:    false,
│ +                             Required:    true,
│ -                             Optional:    true,
│ +                             Optional:    false,
│                               Computed:    false,
│                               Sensitive:   false,
│                               ... // 4 identical fields
│                       },
│                       &{Name: "ca_file", Type: s"tftypes.String", Description: "A path to a PEM-encoded certificate authority used to verify the"..., Optional: true, ...},
│                       &{Name: "ca_pem", Type: s"tftypes.String", Description: "PEM-encoded certificate authority used to verify the remote agen"..., Optional: true, ...},
│                       ... // 9 identical elements
│               },
│               BlockTypes:  {&{TypeName: "auth_jwt", Block: &{Attributes: {&{Name: "auth_method", Type: s"tftypes.String", Description: "The name of the auth method to use for login.", Required: true, ...}, &{Name: "login_token", Type: s"tftypes.String", Description: "The externally issued authentication token to be exchanged for a"..., Required: true, ...}}, Description: "Authenticates to Nomad using a JWT authentication method."}, Nesting: s"LIST"}, &{TypeName: "headers", Block: &{Attributes: {&{Name: "name", Type: s"tftypes.String", Description: "The header name", Required: true, ...}, &{Name: "value", Type: s"tftypes.String", Description: "The header value", Required: true, ...}}, Description: "The headers to send with each Nomad request."}, Nesting: s"LIST"}},
│               Description: "",
│               ... // 3 identical fields
│       },
│   }
│ ..
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.
