### PR TITLE
nomad_acl_token: fix perpetual ForceNew on expiration_ttl via DiffSuppressFunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+BUG FIXES:
+* resource/nomad_acl_token: Fixed perpetual destroy-and-recreate cycle when `expiration_ttl` is set to a duration like `"1h"` or `"30m"`. `Read()` normalizes the value via Go's `time.Duration.String()` (e.g. `"1h"` → `"1h0m0s"`), causing a diff with `ForceNew: true`. Added a `DiffSuppressFunc` that compares durations by value using `time.ParseDuration`. ([#615](https://github.com/hashicorp/terraform-provider-nomad/pull/615))
+
 ## 2.6.1 (April 20, 2026)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## UNRELEASED
 
 BUG FIXES:
-* resource/nomad_acl_token: Fixed perpetual destroy-and-recreate cycle when `expiration_ttl` is set to a duration like `"1h"` or `"30m"`. `Read()` normalizes the value via Go's `time.Duration.String()` (e.g. `"1h"` → `"1h0m0s"`), causing a diff with `ForceNew: true`. Added a `DiffSuppressFunc` that compares durations by value using `time.ParseDuration`. ([#615](https://github.com/hashicorp/terraform-provider-nomad/pull/615))
+* resource/nomad_acl_token: Fixed perpetual destroy-and-recreate cycle when `expiration_ttl` is set to a duration like `"1h"` or `"30m"`. ([#615](https://github.com/hashicorp/terraform-provider-nomad/pull/615))
 
 ## 2.6.1 (April 20, 2026)
 

--- a/nomad/resource_acl_token.go
+++ b/nomad/resource_acl_token.go
@@ -91,6 +91,11 @@ func resourceACLToken() *schema.Resource {
 				Default:     "0s",
 				ForceNew:    true,
 				Type:        schema.TypeString,
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					o, _ := time.ParseDuration(oldValue)
+					n, _ := time.ParseDuration(newValue)
+					return o == n
+				},
 			},
 			"expiration_time": {
 				Description: "The point after which a token is considered expired and eligible for destruction.",

--- a/nomad/resource_acl_token.go
+++ b/nomad/resource_acl_token.go
@@ -92,8 +92,11 @@ func resourceACLToken() *schema.Resource {
 				ForceNew:    true,
 				Type:        schema.TypeString,
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-					o, _ := time.ParseDuration(oldValue)
-					n, _ := time.ParseDuration(newValue)
+					o, err1 := time.ParseDuration(oldValue)
+					n, err2 := time.ParseDuration(newValue)
+					if err1 != nil || err2 != nil {
+						return false
+					}
 					return o == n
 				},
 			},


### PR DESCRIPTION
## Summary

Fixes #614

`expiration_ttl` on `nomad_acl_token` caused a perpetual destroy-and-recreate cycle when set to durations like `"1h"` or `"30m"`. `Read()` writes back the value via `token.ExpirationTTL.String()`, which Go normalizes to `"1h0m0s"` — a string that does not match the original config value. With `ForceNew: true` and no `DiffSuppressFunc`, every `terraform plan` schedules a replacement, silently rotating `secret_id` and breaking downstream services.

## Change

Added a `DiffSuppressFunc` to `expiration_ttl` that parses both old and new values with `time.ParseDuration` and suppresses the diff when they represent the same duration.

This is the same pattern already used in this repo for `max_token_ttl` in `resource_acl_auth_method.go`.

## Testing

Verified locally with provider built from this branch against Nomad v2.0.0:

```
# Before fix
terraform plan → expiration_ttl = "1h0m0s" -> "1h" # forces replacement  (exit code 2)

# After fix
terraform plan → No changes.  (exit code 0)
```