### PR TITLE
fix(datasource/nomad_variable): fix panic when items_wo_version is not in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 BUG FIXES:
+* data source/nomad_variable: Fix panic when reading a variable due to `items_wo_version` not being in the data source schema. ([#625](https://github.com/hashicorp/terraform-provider-nomad/pull/625))
 * resource/nomad_acl_token: Fixed perpetual destroy-and-recreate cycle when `expiration_ttl` is set to a duration like `"1h"` or `"30m"`. ([#615](https://github.com/hashicorp/terraform-provider-nomad/pull/615))
 
 ## 2.6.1 (April 20, 2026)

--- a/nomad/data_source_variable_test.go
+++ b/nomad/data_source_variable_test.go
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2016, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package nomad
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestDataSourceVariable_basic(t *testing.T) {
+	path := acctest.RandomWithPrefix("tf-nomad-test")
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "1.4.0") },
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceVariable_config(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.nomad_variable.test", "path", path),
+					resource.TestCheckResourceAttr("data.nomad_variable.test", "items.test_key", "test_value"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceVariable_config(path string) string {
+	return fmt.Sprintf(`
+resource "nomad_variable" "test" {
+  path = "%s"
+
+  items = {
+    test_key = "test_value"
+  }
+}
+
+data "nomad_variable" "test" {
+  path       = "%s"
+  depends_on = [nomad_variable.test]
+}
+`, path, path)
+}

--- a/nomad/resource_variable.go
+++ b/nomad/resource_variable.go
@@ -152,7 +152,7 @@ func resourceVariableRead(d *schema.ResourceData, meta any) error {
 
 	d.SetId(variableID)
 
-	if d.Get("items_wo_version").(int) > 0 {
+	if v, ok := d.GetOk("items_wo_version"); ok && v.(int) > 0 {
 		return d.Set("items", nil)
 	}
 


### PR DESCRIPTION
### Description

The shared `resourceVariableRead` function panics with a nil type assertion when called from the data source, which does not declare `items_wo_version` in its schema. Use `d.GetOk` to safely check for the attribute.

Add data source acceptance test to prevent future regressions.

Fixes #623 

[JIRA Ticket](https://hashicorp.atlassian.net/browse/NMD-1491)

### Testing & Reproduction steps

1. Reproduce the panic (before fix) :- apply the following config with provider v2.6.0 or v2.6.1:
```terraform
resource "nomad_variable" "test" {
  path  = "example/test"
  items = { secret = "abc" }
}

data "nomad_variable" "test" {
  path       = "example/test"
  depends_on = [nomad_variable.test]
}

output "secret" {
  value     = data.nomad_variable.test.items["secret"]
  sensitive = true
}
```
Expected panic:
```
panic: interface conversion: interface {} is nil, not int
```

2. Verify the fix :- rebuild the provider from this branch and re-run the same config. The data source should read successfully and return items without panic.
3. Run acceptance tests:
```bash
TF_ACC=1 go test ./nomad -run TestDataSourceVariable -count=1 -v
TF_ACC=1 go test ./nomad -run TestResourceVariable -count=1 -v
```
Both should pass :- confirming the data source works and the resource's `items_wo_version` behavior is unaffected.



<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.
