### PR TITLE
feat: add nomad_service and nomad_services data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## UNRELEASED
 
 IMPROVEMENTS:
+* **New Data Source**: `nomad_service` retrieves registrations for a specific Nomad-native service. ([#629](https://github.com/hashicorp/terraform-provider-nomad/pull/629))
+* **New Data Source**: `nomad_services` lists all services registered with Nomad's native service discovery. ([#629](https://github.com/hashicorp/terraform-provider-nomad/pull/629))
 * resource/nomad_csi_volume: migrate to Plugin Framework and add write-only attributes `secrets_wo` and `secrets_wo_version` to avoid storing secrets in state. ([#628](https://github.com/hashicorp/terraform-provider-nomad/pull/628))
 * resource/nomad_csi_volume_registration: migrate to Plugin Framework and add write-only attributes `secrets_wo` and `secrets_wo_version` to avoid storing secrets in state. ([#628](https://github.com/hashicorp/terraform-provider-nomad/pull/628))
 * resource/nomad_sentinel_policy: add `submit-host-volume` and `submit-csi-volume` scope support. ([#624](https://github.com/hashicorp/terraform-provider-nomad/pull/624))

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/acl"
+	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/services"
 	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/variables"
 	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/volumes"
 )
@@ -148,7 +149,10 @@ func (p *NomadProvider) Resources(_ context.Context) []func() resource.Resource 
 }
 
 func (p *NomadProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	return nil
+	return []func() datasource.DataSource{
+		services.NewServiceDataSource,
+		services.NewServicesDataSource,
+	}
 }
 
 func (p *NomadProvider) EphemeralResources(_ context.Context) []func() ephemeral.EphemeralResource {

--- a/internal/framework/provider/services/datasource_service.go
+++ b/internal/framework/provider/services/datasource_service.go
@@ -204,10 +204,11 @@ func (d *ServiceDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	data.ID = types.StringValue(serviceName)
 	if data.Namespace.IsNull() || data.Namespace.IsUnknown() {
 		data.Namespace = types.StringValue("default")
 	}
+
+	data.ID = types.StringValue(data.Namespace.ValueString() + "/" + serviceName)
 
 	regList := make([]attr.Value, 0, len(registrations))
 	for _, reg := range registrations {

--- a/internal/framework/provider/services/datasource_service.go
+++ b/internal/framework/provider/services/datasource_service.go
@@ -1,0 +1,255 @@
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-nomad/nomad"
+)
+
+var _ datasource.DataSource = &ServiceDataSource{}
+var _ datasource.DataSourceWithConfigure = &ServiceDataSource{}
+
+type ServiceDataSource struct {
+	providerConfig nomad.ProviderConfig
+}
+
+func NewServiceDataSource() datasource.DataSource {
+	return &ServiceDataSource{}
+}
+
+type serviceModel struct {
+	ID            types.String `tfsdk:"id"`
+	ServiceName   types.String `tfsdk:"service_name"`
+	Namespace     types.String `tfsdk:"namespace"`
+	Filter        types.String `tfsdk:"filter"`
+	Choose        types.String `tfsdk:"choose"`
+	Registrations types.List   `tfsdk:"registrations"`
+}
+
+var registrationObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"id":           types.StringType,
+		"address":      types.StringType,
+		"port":         types.Int64Type,
+		"node_id":      types.StringType,
+		"datacenter":   types.StringType,
+		"alloc_id":     types.StringType,
+		"job_id":       types.StringType,
+		"namespace":    types.StringType,
+		"tags":         types.ListType{ElemType: types.StringType},
+		"create_index": types.Int64Type,
+		"modify_index": types.Int64Type,
+	},
+}
+
+func (d *ServiceDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_service"
+}
+
+func (d *ServiceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Retrieve information about a specific Nomad service and its registrations.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of this data source.",
+			},
+			"service_name": schema.StringAttribute{
+				Required:    true,
+				Description: "The name of the service to look up.",
+			},
+			"namespace": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The namespace of the service. Defaults to \"default\".",
+			},
+			"filter": schema.StringAttribute{
+				Optional:    true,
+				Description: "A Nomad filter expression to apply to the service registrations. See https://developer.hashicorp.com/nomad/api-docs#filtering for syntax.",
+			},
+			"choose": schema.StringAttribute{
+				Optional:    true,
+				Description: "Specifies the number of services to return and a hash key for rendezvous hashing. Must be in the form \"<number>|<key>\".",
+			},
+			"registrations": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "The list of service registrations matching the query.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed:    true,
+							Description: "The unique identifier of the service registration.",
+						},
+						"address": schema.StringAttribute{
+							Computed:    true,
+							Description: "The IP address of the service registration.",
+						},
+						"port": schema.Int64Attribute{
+							Computed:    true,
+							Description: "The port number of the service registration.",
+						},
+						"node_id": schema.StringAttribute{
+							Computed:    true,
+							Description: "The ID of the node where the service is running.",
+						},
+						"datacenter": schema.StringAttribute{
+							Computed:    true,
+							Description: "The datacenter of the node where the service is running.",
+						},
+						"alloc_id": schema.StringAttribute{
+							Computed:    true,
+							Description: "The ID of the allocation providing this service.",
+						},
+						"job_id": schema.StringAttribute{
+							Computed:    true,
+							Description: "The ID of the job that registered this service.",
+						},
+						"namespace": schema.StringAttribute{
+							Computed:    true,
+							Description: "The namespace of the service registration.",
+						},
+						"tags": schema.ListAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+							Description: "The tags associated with this service registration.",
+						},
+						"create_index": schema.Int64Attribute{
+							Computed:    true,
+							Description: "The Raft index when this registration was created.",
+						},
+						"modify_index": schema.Int64Attribute{
+							Computed:    true,
+							Description: "The Raft index when this registration was last modified.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *ServiceDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	metaFunc, ok := req.ProviderData.(func() any)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected DataSource Configure Type",
+			fmt.Sprintf("Expected func() any, got %T.", req.ProviderData),
+		)
+		return
+	}
+
+	providerConfig, ok := metaFunc().(nomad.ProviderConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider Meta Type",
+			fmt.Sprintf("Expected nomad.ProviderConfig, got %T.", metaFunc()),
+		)
+		return
+	}
+
+	d.providerConfig = providerConfig
+}
+
+func (d *ServiceDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data serviceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := d.providerConfig.Client()
+	serviceName := data.ServiceName.ValueString()
+
+	qOpts := &api.QueryOptions{}
+	if !data.Namespace.IsNull() && !data.Namespace.IsUnknown() {
+		qOpts.Namespace = data.Namespace.ValueString()
+	}
+
+	if !data.Choose.IsNull() && !data.Choose.IsUnknown() {
+		qOpts.Params = map[string]string{
+			"choose": data.Choose.ValueString(),
+		}
+	}
+
+	if !data.Filter.IsNull() && !data.Filter.IsUnknown() {
+		qOpts.Filter = data.Filter.ValueString()
+	}
+
+	tflog.Debug(ctx, "reading Nomad service", map[string]interface{}{
+		"service_name": serviceName,
+		"namespace":    qOpts.Namespace,
+	})
+
+	registrations, _, err := client.Services().Get(serviceName, qOpts)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading Nomad service",
+			fmt.Sprintf("Unable to read service %q: %s", serviceName, err),
+		)
+		return
+	}
+
+	data.ID = types.StringValue(serviceName)
+	if data.Namespace.IsNull() || data.Namespace.IsUnknown() {
+		data.Namespace = types.StringValue("default")
+	}
+
+	regList := make([]attr.Value, 0, len(registrations))
+	for _, reg := range registrations {
+		tagValues := make([]attr.Value, 0, len(reg.Tags))
+		for _, tag := range reg.Tags {
+			tagValues = append(tagValues, types.StringValue(tag))
+		}
+		tagsList, diags := types.ListValue(types.StringType, tagValues)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		regObj, diags := types.ObjectValue(
+			registrationObjectType.AttrTypes,
+			map[string]attr.Value{
+				"id":           types.StringValue(reg.ID),
+				"address":      types.StringValue(reg.Address),
+				"port":         types.Int64Value(int64(reg.Port)),
+				"node_id":      types.StringValue(reg.NodeID),
+				"datacenter":   types.StringValue(reg.Datacenter),
+				"alloc_id":     types.StringValue(reg.AllocID),
+				"job_id":       types.StringValue(reg.JobID),
+				"namespace":    types.StringValue(reg.Namespace),
+				"tags":         tagsList,
+				"create_index": types.Int64Value(int64(reg.CreateIndex)),
+				"modify_index": types.Int64Value(int64(reg.ModifyIndex)),
+			},
+		)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		regList = append(regList, regObj)
+	}
+
+	registrationsList, diags := types.ListValue(registrationObjectType, regList)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.Registrations = registrationsList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/framework/provider/services/datasource_service.go
+++ b/internal/framework/provider/services/datasource_service.go
@@ -28,7 +28,6 @@ func NewServiceDataSource() datasource.DataSource {
 }
 
 type serviceModel struct {
-	ID            types.String `tfsdk:"id"`
 	ServiceName   types.String `tfsdk:"service_name"`
 	Namespace     types.String `tfsdk:"namespace"`
 	Filter        types.String `tfsdk:"filter"`
@@ -60,10 +59,6 @@ func (d *ServiceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 	resp.Schema = schema.Schema{
 		Description: "Retrieve information about a specific Nomad service and its registrations.",
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed:    true,
-				Description: "The ID of this data source.",
-			},
 			"service_name": schema.StringAttribute{
 				Required:    true,
 				Description: "The name of the service to look up.",
@@ -207,8 +202,6 @@ func (d *ServiceDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if data.Namespace.IsNull() || data.Namespace.IsUnknown() {
 		data.Namespace = types.StringValue("default")
 	}
-
-	data.ID = types.StringValue(data.Namespace.ValueString() + "/" + serviceName)
 
 	regList := make([]attr.Value, 0, len(registrations))
 	for _, reg := range registrations {

--- a/internal/framework/provider/services/datasource_service.go
+++ b/internal/framework/provider/services/datasource_service.go
@@ -83,7 +83,7 @@ func (d *ServiceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
 							Computed:    true,
-							Description: "The unique identifier of the service registration.",
+							Description: "The unique identifier of the service registration for a specific allocation.",
 						},
 						"address": schema.StringAttribute{
 							Computed:    true,

--- a/internal/framework/provider/services/datasource_service_test.go
+++ b/internal/framework/provider/services/datasource_service_test.go
@@ -34,7 +34,7 @@ func TestAccDataSourceNomadService_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.nomad_service.test",
 						tfjsonpath.New("id"),
-						knownvalue.StringExact("webapp"),
+						knownvalue.StringExact("default/webapp"),
 					),
 					statecheck.ExpectKnownValue(
 						"data.nomad_service.test",
@@ -86,7 +86,7 @@ func TestAccDataSourceNomadService_choose(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.nomad_service.test",
 						tfjsonpath.New("id"),
-						knownvalue.StringExact("webapp-choose"),
+						knownvalue.StringExact("default/webapp-choose"),
 					),
 					statecheck.ExpectKnownValue(
 						"data.nomad_service.test",

--- a/internal/framework/provider/services/datasource_service_test.go
+++ b/internal/framework/provider/services/datasource_service_test.go
@@ -4,13 +4,16 @@
 package services_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/testutil"
+	"github.com/shoenig/test/must"
 )
 
 func TestAccDataSourceNomadService_basic(t *testing.T) {
@@ -24,12 +27,42 @@ func TestAccDataSourceNomadService_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.nomad_service.test", "service_name", "webapp"),
 					resource.TestCheckResourceAttr("data.nomad_service.test", "namespace", "default"),
+					resource.TestCheckResourceAttrSet("data.nomad_service.test", "registrations.#"),
+					testCheckServiceRegistrations(t, "webapp"),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.nomad_service.test",
+						tfjsonpath.New("id"),
+						knownvalue.StringExact("webapp"),
+					),
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
 						tfjsonpath.New("service_name"),
 						knownvalue.StringExact("webapp"),
+					),
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("namespace"),
+						knownvalue.StringExact("default"),
+					),
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("registrations"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("registrations").AtSliceIndex(0).AtMapKey("namespace"),
+						knownvalue.StringExact("default"),
+					),
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("registrations").AtSliceIndex(0).AtMapKey("tags"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("http"),
+							knownvalue.StringExact("test"),
+						}),
 					),
 				},
 			},
@@ -47,10 +80,77 @@ func TestAccDataSourceNomadService_choose(t *testing.T) {
 				Config:    testAccDataSourceNomadServiceChooseConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.nomad_service.test", "service_name", "webapp-choose"),
+					resource.TestCheckResourceAttr("data.nomad_service.test", "registrations.#", "1"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("id"),
+						knownvalue.StringExact("webapp-choose"),
+					),
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("registrations"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("registrations").AtSliceIndex(0).AtMapKey("address"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("registrations").AtSliceIndex(0).AtMapKey("node_id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("registrations").AtSliceIndex(0).AtMapKey("alloc_id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("registrations").AtSliceIndex(0).AtMapKey("job_id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("registrations").AtSliceIndex(0).AtMapKey("datacenter"),
+						knownvalue.StringExact("dc1"),
+					),
+				},
 			},
 		},
 	})
+}
+
+// testCheckServiceRegistrations verifies that registrations exist and have
+// expected fields populated.
+func testCheckServiceRegistrations(t *testing.T, serviceName string) resource.TestCheckFunc {
+	t.Helper()
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources["data.nomad_service.test"]
+		must.True(t, ok, must.Sprintf("data.nomad_service.test not found in state"))
+
+		attrs := rs.Primary.Attributes
+		must.Eq(t, serviceName, attrs["service_name"])
+		must.NotEq(t, "0", attrs["registrations.#"],
+			must.Sprintf("expected at least one registration"))
+
+		// Verify the first registration has required fields set.
+		must.NotEq(t, "", attrs["registrations.0.id"],
+			must.Sprintf("registration id should not be empty"))
+		must.NotEq(t, "", attrs["registrations.0.node_id"],
+			must.Sprintf("registration node_id should not be empty"))
+		must.NotEq(t, "", attrs["registrations.0.alloc_id"],
+			must.Sprintf("registration alloc_id should not be empty"))
+		must.NotEq(t, "", attrs["registrations.0.job_id"],
+			must.Sprintf("registration job_id should not be empty"))
+		must.NotEq(t, "", attrs[fmt.Sprintf("registrations.0.port")],
+			must.Sprintf("registration port should not be empty"))
+
+		return nil
+	}
 }
 
 func testAccDataSourceNomadServiceConfig() string {

--- a/internal/framework/provider/services/datasource_service_test.go
+++ b/internal/framework/provider/services/datasource_service_test.go
@@ -33,11 +33,6 @@ func TestAccDataSourceNomadService_basic(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"data.nomad_service.test",
-						tfjsonpath.New("id"),
-						knownvalue.StringExact("default/webapp"),
-					),
-					statecheck.ExpectKnownValue(
-						"data.nomad_service.test",
 						tfjsonpath.New("service_name"),
 						knownvalue.StringExact("webapp"),
 					),
@@ -83,11 +78,6 @@ func TestAccDataSourceNomadService_choose(t *testing.T) {
 					resource.TestCheckResourceAttr("data.nomad_service.test", "registrations.#", "1"),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"data.nomad_service.test",
-						tfjsonpath.New("id"),
-						knownvalue.StringExact("default/webapp-choose"),
-					),
 					statecheck.ExpectKnownValue(
 						"data.nomad_service.test",
 						tfjsonpath.New("registrations"),

--- a/internal/framework/provider/services/datasource_service_test.go
+++ b/internal/framework/provider/services/datasource_service_test.go
@@ -1,4 +1,5 @@
-// Copyright IBM Corp. 2017, 2026
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
 
 package services_test
 

--- a/internal/framework/provider/services/datasource_service_test.go
+++ b/internal/framework/provider/services/datasource_service_test.go
@@ -1,0 +1,70 @@
+// Copyright IBM Corp. 2017, 2026
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/testutil"
+)
+
+func TestAccDataSourceNomadService_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { registerTestService(t, "webapp", "default") },
+				Config:    testAccDataSourceNomadServiceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.nomad_service.test", "service_name", "webapp"),
+					resource.TestCheckResourceAttr("data.nomad_service.test", "namespace", "default"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.nomad_service.test",
+						tfjsonpath.New("service_name"),
+						knownvalue.StringExact("webapp"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNomadService_choose(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { registerTestService(t, "webapp-choose", "default") },
+				Config:    testAccDataSourceNomadServiceChooseConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.nomad_service.test", "service_name", "webapp-choose"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceNomadServiceConfig() string {
+	return `
+data "nomad_service" "test" {
+  service_name = "webapp"
+}
+`
+}
+
+func testAccDataSourceNomadServiceChooseConfig() string {
+	return `
+data "nomad_service" "test" {
+  service_name = "webapp-choose"
+  choose       = "1|mykey"
+}
+`
+}

--- a/internal/framework/provider/services/datasource_services.go
+++ b/internal/framework/provider/services/datasource_services.go
@@ -1,0 +1,178 @@
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-nomad/nomad"
+)
+
+var _ datasource.DataSource = &ServicesDataSource{}
+var _ datasource.DataSourceWithConfigure = &ServicesDataSource{}
+
+type ServicesDataSource struct {
+	providerConfig nomad.ProviderConfig
+}
+
+func NewServicesDataSource() datasource.DataSource {
+	return &ServicesDataSource{}
+}
+
+type servicesModel struct {
+	ID        types.String `tfsdk:"id"`
+	Namespace types.String `tfsdk:"namespace"`
+	Services  types.List   `tfsdk:"services"`
+}
+
+var serviceStubObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"namespace": types.StringType,
+		"name":      types.StringType,
+		"tags":      types.ListType{ElemType: types.StringType},
+	},
+}
+
+func (d *ServicesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_services"
+}
+
+func (d *ServicesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Retrieve the list of all registered Nomad services.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of this data source.",
+			},
+			"namespace": schema.StringAttribute{
+				Optional:    true,
+				Description: "The namespace to filter services. Use \"*\" for all namespaces.",
+			},
+			"services": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "The list of services found.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"namespace": schema.StringAttribute{
+							Computed:    true,
+							Description: "The namespace in which the service is registered.",
+						},
+						"name": schema.StringAttribute{
+							Computed:    true,
+							Description: "The name of the service.",
+						},
+						"tags": schema.ListAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+							Description: "The tags associated with the service.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *ServicesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	metaFunc, ok := req.ProviderData.(func() any)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected DataSource Configure Type",
+			fmt.Sprintf("Expected func() any, got %T.", req.ProviderData),
+		)
+		return
+	}
+
+	providerConfig, ok := metaFunc().(nomad.ProviderConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider Meta Type",
+			fmt.Sprintf("Expected nomad.ProviderConfig, got %T.", metaFunc()),
+		)
+		return
+	}
+
+	d.providerConfig = providerConfig
+}
+
+func (d *ServicesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data servicesModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := d.providerConfig.Client()
+
+	qOpts := &api.QueryOptions{}
+	if !data.Namespace.IsNull() && !data.Namespace.IsUnknown() {
+		qOpts.Namespace = data.Namespace.ValueString()
+	}
+
+	tflog.Debug(ctx, "listing Nomad services", map[string]interface{}{
+		"namespace": qOpts.Namespace,
+	})
+
+	serviceStubs, _, err := client.Services().List(qOpts)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error listing Nomad services",
+			fmt.Sprintf("Unable to list services: %s", err),
+		)
+		return
+	}
+
+	data.ID = types.StringValue("nomad-services")
+
+	svcList := make([]attr.Value, 0)
+	for _, nsStub := range serviceStubs {
+		for _, svc := range nsStub.Services {
+			tagValues := make([]attr.Value, 0, len(svc.Tags))
+			for _, tag := range svc.Tags {
+				tagValues = append(tagValues, types.StringValue(tag))
+			}
+			tagsList, diags := types.ListValue(types.StringType, tagValues)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			svcObj, diags := types.ObjectValue(
+				serviceStubObjectType.AttrTypes,
+				map[string]attr.Value{
+					"namespace": types.StringValue(nsStub.Namespace),
+					"name":      types.StringValue(svc.ServiceName),
+					"tags":      tagsList,
+				},
+			)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			svcList = append(svcList, svcObj)
+		}
+	}
+
+	servicesList, diags := types.ListValue(serviceStubObjectType, svcList)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.Services = servicesList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/framework/provider/services/datasource_services.go
+++ b/internal/framework/provider/services/datasource_services.go
@@ -28,7 +28,6 @@ func NewServicesDataSource() datasource.DataSource {
 }
 
 type servicesModel struct {
-	ID        types.String `tfsdk:"id"`
 	Namespace types.String `tfsdk:"namespace"`
 	Services  types.List   `tfsdk:"services"`
 }
@@ -49,10 +48,6 @@ func (d *ServicesDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 	resp.Schema = schema.Schema{
 		Description: "Retrieve the list of all registered Nomad services.",
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed:    true,
-				Description: "The ID of this data source.",
-			},
 			"namespace": schema.StringAttribute{
 				Optional:    true,
 				Description: "The namespace to filter services. Use \"*\" for all namespaces.",
@@ -135,8 +130,6 @@ func (d *ServicesDataSource) Read(ctx context.Context, req datasource.ReadReques
 		)
 		return
 	}
-
-	data.ID = types.StringValue("nomad-services")
 
 	svcList := make([]attr.Value, 0)
 	for _, nsStub := range serviceStubs {

--- a/internal/framework/provider/services/datasource_services.go
+++ b/internal/framework/provider/services/datasource_services.go
@@ -50,7 +50,7 @@ func (d *ServicesDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 		Attributes: map[string]schema.Attribute{
 			"namespace": schema.StringAttribute{
 				Optional:    true,
-				Description: "The namespace to filter services. Use \"*\" for all namespaces.",
+				Description: "The namespace to filter services. If not provided, defaults to \"default\". Use \"*\" for all namespaces.",
 			},
 			"services": schema.ListNestedAttribute{
 				Computed:    true,

--- a/internal/framework/provider/services/datasource_services_test.go
+++ b/internal/framework/provider/services/datasource_services_test.go
@@ -4,6 +4,7 @@
 package services_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -11,9 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/testutil"
 	"github.com/hashicorp/terraform-provider-nomad/nomad"
+	"github.com/shoenig/test/must"
 )
 
 func TestAccDataSourceNomadServices_basic(t *testing.T) {
@@ -26,6 +29,7 @@ func TestAccDataSourceNomadServices_basic(t *testing.T) {
 				Config:    testAccDataSourceNomadServicesConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.nomad_services.test", "services.#"),
+					testCheckServicesContain(t, "services-list-webapp", "default"),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -49,7 +53,9 @@ func TestAccDataSourceNomadServices_namespace(t *testing.T) {
 				Config:    testAccDataSourceNomadServicesNamespaceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.nomad_services.test", "services.#"),
+					testCheckServicesContain(t, "services-ns-webapp", "default"),
 				),
+
 			},
 		},
 	})
@@ -69,14 +75,52 @@ data "nomad_services" "test" {
 `
 }
 
+// testCheckServicesContain verifies that the services list in state contains a
+// service with the given name and namespace, and validates its tags.
+func testCheckServicesContain(t *testing.T, serviceName, namespace string) resource.TestCheckFunc {
+	t.Helper()
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources["data.nomad_services.test"]
+		must.True(t, ok, must.Sprintf("data.nomad_services.test not found in state"))
+
+		attrs := rs.Primary.Attributes
+		numServices := attrs["services.#"]
+		must.NotEq(t, "0", numServices, must.Sprintf("expected at least one service"))
+
+		for i := 0; ; i++ {
+			name, exists := attrs[fmt.Sprintf("services.%d.name", i)]
+			if !exists {
+				break
+			}
+			ns := attrs[fmt.Sprintf("services.%d.namespace", i)]
+			if name == serviceName && ns == namespace {
+				// Verify tags are present.
+				tagsCount := attrs[fmt.Sprintf("services.%d.tags.#", i)]
+				must.Eq(t, "2", tagsCount,
+					must.Sprintf("expected 2 tags for service %s", serviceName))
+				// Collect tags and verify both expected tags exist.
+				tags := make(map[string]struct{})
+				for j := 0; j < 2; j++ {
+					tags[attrs[fmt.Sprintf("services.%d.tags.%d", i, j)]] = struct{}{}
+				}
+				_, hasHTTP := tags["http"]
+				_, hasTest := tags["test"]
+				must.True(t, hasHTTP, must.Sprintf("expected 'http' tag"))
+				must.True(t, hasTest, must.Sprintf("expected 'test' tag"))
+				return nil
+			}
+		}
+		t.Fatalf("service %q in namespace %q not found in services list", serviceName, namespace)
+		return nil
+	}
+}
+
 func registerTestService(t *testing.T, serviceName, namespace string) {
 	t.Helper()
 
 	providerData := testutil.SDKV2ProviderMeta(t)()
 	providerConfig, ok := providerData.(nomad.ProviderConfig)
-	if !ok {
-		t.Fatalf("expected nomad.ProviderConfig, got %T", providerData)
-	}
+	must.True(t, ok, must.Sprintf("expected nomad.ProviderConfig, got %T", providerData))
 
 	client := providerConfig.Client()
 
@@ -122,9 +166,7 @@ func registerTestService(t *testing.T, serviceName, namespace string) {
 	}
 
 	_, _, err := client.Jobs().Register(job, &api.WriteOptions{Namespace: namespace})
-	if err != nil {
-		t.Fatalf("failed to register test job: %v", err)
-	}
+	must.NoError(t, err, must.Sprintf("failed to register test job"))
 
 	// Wait for the service to be registered.
 	deadline := time.Now().Add(30 * time.Second)

--- a/internal/framework/provider/services/datasource_services_test.go
+++ b/internal/framework/provider/services/datasource_services_test.go
@@ -159,13 +159,16 @@ func registerTestService(t *testing.T, serviceName, namespace string) {
 
 	// Wait for the service to be registered.
 	deadline := time.Now().Add(30 * time.Second)
+	var found bool
 	for time.Now().Before(deadline) {
 		services, _, err := client.Services().Get(serviceName, &api.QueryOptions{Namespace: namespace})
 		if err == nil && len(services) > 0 {
+			found = true
 			break
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
+	must.True(t, found, must.Sprintf("service %q not registered within timeout", serviceName))
 
 	t.Cleanup(func() {
 		client.Jobs().Deregister(*job.ID, true, &api.WriteOptions{Namespace: namespace})

--- a/internal/framework/provider/services/datasource_services_test.go
+++ b/internal/framework/provider/services/datasource_services_test.go
@@ -10,10 +10,7 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
-	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/testutil"
 	"github.com/hashicorp/terraform-provider-nomad/nomad"
 	"github.com/shoenig/test/must"
@@ -31,13 +28,6 @@ func TestAccDataSourceNomadServices_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.nomad_services.test", "services.#"),
 					testCheckServicesContain(t, "services-list-webapp", "default"),
 				),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"data.nomad_services.test",
-						tfjsonpath.New("id"),
-						knownvalue.StringExact("nomad-services"),
-					),
-				},
 			},
 		},
 	})

--- a/internal/framework/provider/services/datasource_services_test.go
+++ b/internal/framework/provider/services/datasource_services_test.go
@@ -55,7 +55,6 @@ func TestAccDataSourceNomadServices_namespace(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.nomad_services.test", "services.#"),
 					testCheckServicesContain(t, "services-ns-webapp", "default"),
 				),
-
 			},
 		},
 	})

--- a/internal/framework/provider/services/datasource_services_test.go
+++ b/internal/framework/provider/services/datasource_services_test.go
@@ -1,4 +1,5 @@
-// Copyright IBM Corp. 2017, 2026
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
 
 package services_test
 

--- a/internal/framework/provider/services/datasource_services_test.go
+++ b/internal/framework/provider/services/datasource_services_test.go
@@ -1,0 +1,145 @@
+// Copyright IBM Corp. 2017, 2026
+
+package services_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-nomad/internal/framework/provider/testutil"
+	"github.com/hashicorp/terraform-provider-nomad/nomad"
+)
+
+func TestAccDataSourceNomadServices_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { registerTestService(t, "services-list-webapp", "default") },
+				Config:    testAccDataSourceNomadServicesConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.nomad_services.test", "services.#"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.nomad_services.test",
+						tfjsonpath.New("id"),
+						knownvalue.StringExact("nomad-services"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNomadServices_namespace(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { registerTestService(t, "services-ns-webapp", "default") },
+				Config:    testAccDataSourceNomadServicesNamespaceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.nomad_services.test", "services.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceNomadServicesConfig() string {
+	return `
+data "nomad_services" "test" {}
+`
+}
+
+func testAccDataSourceNomadServicesNamespaceConfig() string {
+	return `
+data "nomad_services" "test" {
+  namespace = "default"
+}
+`
+}
+
+func registerTestService(t *testing.T, serviceName, namespace string) {
+	t.Helper()
+
+	providerData := testutil.SDKV2ProviderMeta(t)()
+	providerConfig, ok := providerData.(nomad.ProviderConfig)
+	if !ok {
+		t.Fatalf("expected nomad.ProviderConfig, got %T", providerData)
+	}
+
+	client := providerConfig.Client()
+
+	// Register a job with a Nomad-native service to create a service registration.
+	job := &api.Job{
+		ID:          pointerOf("services-test-" + serviceName),
+		Name:        pointerOf("services-test-" + serviceName),
+		Type:        pointerOf("service"),
+		Datacenters: []string{"dc1"},
+		TaskGroups: []*api.TaskGroup{
+			{
+				Name:  pointerOf("web"),
+				Count: pointerOf(1),
+				Networks: []*api.NetworkResource{
+					{
+						DynamicPorts: []api.Port{
+							{Label: "http", To: 8080},
+						},
+					},
+				},
+				Services: []*api.Service{
+					{
+						Name:      serviceName,
+						PortLabel: "http",
+						Provider:  "nomad",
+						Tags:      []string{"http", "test"},
+					},
+				},
+				Tasks: []*api.Task{
+					{
+						Name:   "server",
+						Driver: "docker",
+						Config: map[string]interface{}{
+							"image":   "busybox:1",
+							"command": "httpd",
+							"args":    []string{"-v", "-f", "-p", "8080"},
+							"ports":   []string{"http"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, _, err := client.Jobs().Register(job, &api.WriteOptions{Namespace: namespace})
+	if err != nil {
+		t.Fatalf("failed to register test job: %v", err)
+	}
+
+	// Wait for the service to be registered.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		services, _, err := client.Services().Get(serviceName, &api.QueryOptions{Namespace: namespace})
+		if err == nil && len(services) > 0 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	t.Cleanup(func() {
+		client.Jobs().Deregister(*job.ID, true, &api.WriteOptions{Namespace: namespace})
+	})
+}
+
+func pointerOf[T any](v T) *T {
+	return &v
+}

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -45,8 +45,8 @@ data "nomad_service" "example" {
 The following arguments are supported:
 
 - `service_name` `(string: <required>)` - The name of the service to look up.
-- `namespace` `(string: <optional>)` - The namespace of the service. Defaults
-  to `"default"`.
+- `namespace` `(string: "default")` - The namespace of the service. If not
+  provided, defaults to `"default"` to reflect the Nomad API behavior.
 - `filter` `(string: <optional>)` - Specifies the
   [expression][nomad_api_filter] used to filter the results.
 - `choose` `(string: <optional>)` - Specifies the number of services to return
@@ -57,10 +57,9 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-- `id` `(string)` - The service name used as the data source ID.
 - `registrations` `(list of registrations)` - A list of service registrations
   matching the query. Each registration has the following attributes:
-  - `id` `(string)` - The unique identifier of the service registration.
+  - `id` `(string)` - The unique identifier of the service registration for a specific allocation.
   - `address` `(string)` - The IP address of the service registration.
   - `port` `(int)` - The port number of the service registration.
   - `node_id` `(string)` - The ID of the node where the service is running.

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -1,0 +1,75 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_service"
+sidebar_current: "docs-nomad-datasource-service"
+description: |-
+  Retrieve information about a specific Nomad service and its registrations.
+---
+
+# nomad_service
+
+Retrieve information about a specific Nomad service and its registrations.
+
+## Example Usage
+
+```hcl
+data "nomad_service" "example" {
+  service_name = "my-webapp"
+}
+
+output "service_addresses" {
+  value = [for r in data.nomad_service.example.registrations : "${r.address}:${r.port}"]
+}
+```
+
+### With rendezvous hashing
+
+```hcl
+data "nomad_service" "example" {
+  service_name = "my-webapp"
+  choose       = "2|my-hash-key"
+}
+```
+
+### With filter expression
+
+```hcl
+data "nomad_service" "example" {
+  service_name = "my-webapp"
+  filter       = "\"canary\" in Tags"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `service_name` `(string: <required>)` - The name of the service to look up.
+- `namespace` `(string: <optional>)` - The namespace of the service. Defaults
+  to `"default"`.
+- `filter` `(string: <optional>)` - Specifies the
+  [expression][nomad_api_filter] used to filter the results.
+- `choose` `(string: <optional>)` - Specifies the number of services to return
+  and a hash key for rendezvous hashing. Must be in the form
+  `"<number>|<key>"`.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- `id` `(string)` - The service name used as the data source ID.
+- `registrations` `(list of registrations)` - A list of service registrations
+  matching the query. Each registration has the following attributes:
+  - `id` `(string)` - The unique identifier of the service registration.
+  - `address` `(string)` - The IP address of the service registration.
+  - `port` `(int)` - The port number of the service registration.
+  - `node_id` `(string)` - The ID of the node where the service is running.
+  - `datacenter` `(string)` - The datacenter of the node where the service is running.
+  - `alloc_id` `(string)` - The ID of the allocation providing this service.
+  - `job_id` `(string)` - The ID of the job that registered this service.
+  - `namespace` `(string)` - The namespace of the service registration.
+  - `tags` `(list of string)` - The tags associated with this service registration.
+  - `create_index` `(int)` - The Raft index when this registration was created.
+  - `modify_index` `(int)` - The Raft index when this registration was last modified.
+
+[nomad_api_filter]: https://developer.hashicorp.com/nomad/api-docs#filtering

--- a/website/docs/d/services.html.markdown
+++ b/website/docs/d/services.html.markdown
@@ -40,14 +40,14 @@ data "nomad_services" "everything" {
 
 The following arguments are supported:
 
-- `namespace` `(string: <optional>)` - The namespace to filter services. Use
-  `"*"` to list services across all namespaces.
+- `namespace` `(string: "default")` - The namespace to filter services. If not
+  provided, the Nomad API defaults to the `"default"` namespace. Use `"*"` to
+  list services across all namespaces.
 
 ## Attribute Reference
 
 The following attributes are exported:
 
-- `id` `(string)` - A static ID for this data source.
 - `services` `(list of services)` - A list of services. Each service has the
   following attributes:
   - `namespace` `(string)` - The namespace in which the service is registered.

--- a/website/docs/d/services.html.markdown
+++ b/website/docs/d/services.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_services"
+sidebar_current: "docs-nomad-datasource-services"
+description: |-
+  Retrieve the list of all registered Nomad services.
+---
+
+# nomad_services
+
+Retrieve the list of all registered Nomad services.
+
+## Example Usage
+
+```hcl
+data "nomad_services" "all" {}
+
+output "service_names" {
+  value = [for s in data.nomad_services.all.services : s.name]
+}
+```
+
+### With namespace filter
+
+```hcl
+data "nomad_services" "production" {
+  namespace = "production"
+}
+```
+
+### All namespaces
+
+```hcl
+data "nomad_services" "everything" {
+  namespace = "*"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `namespace` `(string: <optional>)` - The namespace to filter services. Use
+  `"*"` to list services across all namespaces.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- `id` `(string)` - A static ID for this data source.
+- `services` `(list of services)` - A list of services. Each service has the
+  following attributes:
+  - `namespace` `(string)` - The namespace in which the service is registered.
+  - `name` `(string)` - The name of the service.
+  - `tags` `(list of string)` - The tags associated with the service.


### PR DESCRIPTION


### Description
Implements data sources for Nomad's native service discovery API.

- nomad_service: reads registrations for a specific service name, with support for namespace, filter expressions, and rendezvous hashing (choose parameter)
- nomad_services: lists all registered services, with optional namespace filtering

Includes acceptance tests and website documentation.

### Testing & Reproduction steps

#### Prerequisites

1. **Nomad cluster running** (dev mode is fine):
2. Terraform CLI (v1.0+)
3. Build the provider locally
4. Configure Terraform dev override 
5. Register a test service - run a job with `provider = "nomad"`

##### Test `nomad_services` data source
```terraform 
terraform {
  required_providers {
    nomad = {
      source = "hashicorp/nomad"
    }
  }
}

provider "nomad" {
}

data "nomad_services" "all" {}

data "nomad_services" "default_ns" {
  namespace = "default"
}
```

``` bash
terraform plan
```

##### Test `nomad_service` data source
```terraform
terraform {
  required_providers {
    nomad = {
      source = "hashicorp/nomad"
    }
  }
}

provider "nomad" {
  address = "http://127.0.0.1:4646"
}

# Basic lookup
data "nomad_service" "webapp" {
  service_name = "my-webapp"
}

# With filter
data "nomad_service" "canary_only" {
  service_name = "my-webapp"
  filter       = "\"canary\" in Tags"
}

# With choose (rendezvous hashing)
data "nomad_service" "one_instance" {
  service_name = "my-webapp"
  choose       = "1|my-key"
}
```

```bash
terraform plan
```


<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

Fixes #449 
Fixes: https://hashicorp.atlassian.net/browse/NMD-1142
