### PR TITLE
Fix dynamic_host_volume persisting capacity changes to state after failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
 BUG FIXES:
 * data source/nomad_variable: Fix panic when reading a variable due to `items_wo_version` not being in the data source schema. ([#625](https://github.com/hashicorp/terraform-provider-nomad/pull/625))
 * resource/nomad_acl_token: Fixed perpetual destroy-and-recreate cycle when `expiration_ttl` is set to a duration like `"1h"` or `"30m"`. ([#615](https://github.com/hashicorp/terraform-provider-nomad/pull/615))
+* resource/nomad_dynamic_host_volume: Fix `capacity_min` and `capacity_max` being incorrectly persisted to state after a failed update, and suppress spurious diffs from equivalent capacity representations (e.g. `"1GiB"` vs `"1.0 GiB"`). ([#630](https://github.com/hashicorp/terraform-provider-nomad/pull/630))
 
 ## 2.6.1 (April 20, 2026)
 

--- a/nomad/data_source_dynamic_host_volume.go
+++ b/nomad/data_source_dynamic_host_volume.go
@@ -14,7 +14,7 @@ import (
 
 func dataSourceDynamicHostVolume() *schema.Resource {
 	return &schema.Resource{
-		Read: dynamicHostVolumeRead,
+		Read: dynamicHostVolumeReadWithCapacity,
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Description: "Volume ID",
@@ -143,9 +143,20 @@ func dataSourceDynamicHostVolume() *schema.Resource {
 	}
 }
 
-// dynamicHostVolumeRead gets a dynamic host volume from Nomad. This same
-// function is used for the data source and the create/register resources
+// dynamicHostVolumeRead gets a dynamic host volume from Nomad. Used by the
+// registration resource and as the base for dynamicHostVolumeReadWithCapacity.
 func dynamicHostVolumeRead(d *schema.ResourceData, meta any) error {
+	return dynamicHostVolumeReadImpl(d, meta, false)
+}
+
+// dynamicHostVolumeReadWithCapacity reads a dynamic host volume and also sets
+// the capacity_min and capacity_max string fields. Used by the create resource
+// and the data source which have these fields in their schema.
+func dynamicHostVolumeReadWithCapacity(d *schema.ResourceData, meta any) error {
+	return dynamicHostVolumeReadImpl(d, meta, true)
+}
+
+func dynamicHostVolumeReadImpl(d *schema.ResourceData, meta any, setCapacityStrings bool) error {
 	client := meta.(ProviderConfig).client
 
 	ns, id := getDynamicHostVolumeNamespacedID(d)
@@ -175,16 +186,13 @@ func dynamicHostVolumeRead(d *schema.ResourceData, meta any) error {
 		sw.Set(k, v)
 	}
 
-	// TODO: these fields may have been set by the config but if not, we want to
-	// get them from the API. But right now these are getting changed anyways,
-	// so we detect mutations from ex. "1GiB" => "1.0 GiB"
-	if d.Get("capacity") == "" && vol.CapacityBytes > 0 {
-		sw.Set("capacity", humanize.IBytes(uint64(vol.CapacityBytes)))
-	}
-	if d.Get("capacity_min") == "" && vol.RequestedCapacityMinBytes > 0 {
+	// Always set capacity from the API so state reflects reality.
+	sw.Set("capacity", humanize.IBytes(uint64(vol.CapacityBytes)))
+
+	// capacity_min and capacity_max only exist on the create resource and data
+	// source schemas, not on the registration resource.
+	if setCapacityStrings {
 		sw.Set("capacity_min", humanize.IBytes(uint64(vol.RequestedCapacityMinBytes)))
-	}
-	if d.Get("capacity_max") == "" && vol.RequestedCapacityMaxBytes > 0 {
 		sw.Set("capacity_max", humanize.IBytes(uint64(vol.RequestedCapacityMaxBytes)))
 	}
 

--- a/nomad/data_source_dynamic_host_volume.go
+++ b/nomad/data_source_dynamic_host_volume.go
@@ -143,8 +143,9 @@ func dataSourceDynamicHostVolume() *schema.Resource {
 	}
 }
 
-// dynamicHostVolumeRead gets a dynamic host volume from Nomad. Used by the
-// registration resource and as the base for dynamicHostVolumeReadWithCapacity.
+// dynamicHostVolumeRead gets a dynamic host volume from Nomad without setting
+// capacity_min/capacity_max string fields. Used by the registration resource
+// which does not have these fields in its schema.
 func dynamicHostVolumeRead(d *schema.ResourceData, meta any) error {
 	return dynamicHostVolumeReadImpl(d, meta, false)
 }

--- a/nomad/resource_dynamic_host_volume.go
+++ b/nomad/resource_dynamic_host_volume.go
@@ -20,7 +20,7 @@ func resourceDynamicHostVolume() *schema.Resource {
 		Create: resourceDynamicHostVolumeWrite,
 		Update: resourceDynamicHostVolumeWrite,
 		Delete: resourceDynamicHostVolumeDelete,
-		Read:   dynamicHostVolumeRead,
+		Read:   dynamicHostVolumeReadWithCapacity,
 		Exists: resourceDynamicHostVolumeExists,
 
 		Importer: &schema.ResourceImporter{
@@ -75,14 +75,16 @@ func resourceDynamicHostVolume() *schema.Resource {
 				},
 			},
 			"capacity_max": {
-				Description: "Requested maximum capacity",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "Requested maximum capacity",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: dynamicHostVolumeCapacityDiffSuppress,
 			},
 			"capacity_min": {
-				Description: "Requested minimum capacity",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "Requested minimum capacity",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: dynamicHostVolumeCapacityDiffSuppress,
 			},
 			"constraint": {
 				Description: "Constraints",
@@ -239,7 +241,7 @@ func resourceDynamicHostVolumeWrite(d *schema.ResourceData, meta any) error {
 		return fmt.Errorf("error polling for dynamic host volume readiness: %w", err)
 	}
 
-	return dynamicHostVolumeRead(d, meta)
+	return dynamicHostVolumeReadWithCapacity(d, meta)
 }
 
 func dynamicHostVolumeWaitForReady(client *api.Client, ns, id string) error {
@@ -287,6 +289,22 @@ func resourceDynamicHostVolumeExists(d *schema.ResourceData, meta any) (bool, er
 		return false, fmt.Errorf("error checking for dynamic host volume %q: %w", id, err)
 	}
 	return vol != nil, nil
+}
+
+// dynamicHostVolumeCapacityDiffSuppress suppresses diffs for capacity_min and capacity_max
+// when their textual representations differ but the byte values are equivalent.
+func dynamicHostVolumeCapacityDiffSuppress(_ string, oldValue, newValue string, _ *schema.ResourceData) bool {
+	if oldValue == newValue {
+		return true
+	}
+
+	oldBytes, oldErr := humanize.ParseBytes(oldValue)
+	newBytes, newErr := humanize.ParseBytes(newValue)
+	if oldErr != nil || newErr != nil {
+		return false
+	}
+
+	return oldBytes == newBytes
 }
 
 // getDynamicHostVolume is a helper function for the main resource methods

--- a/nomad/resource_dynamic_host_volume_test.go
+++ b/nomad/resource_dynamic_host_volume_test.go
@@ -20,6 +20,29 @@ import (
 const testResourceNameDynamicHostVolume = "nomad_dynamic_host_volume.test"
 const minVersionDHV = "1.10.0"
 
+func TestDynamicHostVolumeCapacityDiffSuppress(t *testing.T) {
+	testCases := []struct {
+		name     string
+		oldValue string
+		newValue string
+		expect   bool
+	}{
+		{name: "identical strings", oldValue: "1GiB", newValue: "1GiB", expect: true},
+		{name: "equivalent representations", oldValue: "1GiB", newValue: "1.0 GiB", expect: true},
+		{name: "equivalent binary/decimal formatting", oldValue: "2048MiB", newValue: "2.0 GiB", expect: true},
+		{name: "different byte values", oldValue: "1GiB", newValue: "2GiB", expect: false},
+		{name: "invalid new value", oldValue: "1GiB", newValue: "bogus", expect: false},
+		{name: "empty values", oldValue: "", newValue: "", expect: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := dynamicHostVolumeCapacityDiffSuppress("", tc.oldValue, tc.newValue, nil)
+			must.Eq(t, tc.expect, actual)
+		})
+	}
+}
+
 func TestResourceDynamicHostVolume_import(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
@@ -91,6 +114,74 @@ func TestResourceDynamicHostVolume_update(t *testing.T) {
 	})
 }
 
+// TestResourceDynamicHostVolume_updateSameCapacityDifferentFormat verifies that
+// changing only the string representation of capacity (e.g. "1.0 GiB" -> "1GiB")
+// does not trigger an update when the byte values are equivalent.
+func TestResourceDynamicHostVolume_updateSameCapacityDifferentFormat(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-nomad-test")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, minVersionDHV) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceDynamicHostVolume_capacityConfig(name, "1.0 GiB", "12 GiB"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceNameDynamicHostVolume, "name", name),
+					resource.TestCheckResourceAttr(testResourceNameDynamicHostVolume, "capacity_min_bytes", "1073741824"),
+					resource.TestCheckResourceAttr(testResourceNameDynamicHostVolume, "capacity_max_bytes", "12884901888"),
+				),
+			},
+			{
+				// Same bytes, different string format — should be a no-op
+				Config:   testResourceDynamicHostVolume_capacityConfig(name, "1GiB", "12GiB"),
+				PlanOnly: true,
+			},
+			{
+				// Another equivalent format — should also be a no-op
+				Config:   testResourceDynamicHostVolume_capacityConfig(name, "1024MiB", "12288MiB"),
+				PlanOnly: true,
+			},
+		},
+		CheckDestroy: testResourceDynamicHostVolume_checkDestroy(
+			testResourceNameDynamicHostVolume),
+	})
+}
+
+func TestResourceDynamicHostVolume_updateCapacityChange(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-nomad-test")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, minVersionDHV) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceDynamicHostVolume_capacityConfig(name, "1GiB", "10GiB"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceNameDynamicHostVolume, "capacity_min_bytes", "1073741824"),
+					resource.TestCheckResourceAttr(testResourceNameDynamicHostVolume, "capacity_max_bytes", "10737418240"),
+				),
+			},
+			{
+				// Increase capacity
+				Config: testResourceDynamicHostVolume_capacityConfig(name, "2GiB", "20GiB"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceNameDynamicHostVolume, "capacity_min_bytes", "2147483648"),
+					resource.TestCheckResourceAttr(testResourceNameDynamicHostVolume, "capacity_max_bytes", "21474836480"),
+				),
+			},
+			{
+				// Revert capacity back to original
+				Config: testResourceDynamicHostVolume_capacityConfig(name, "1GiB", "10GiB"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceNameDynamicHostVolume, "capacity_min_bytes", "1073741824"),
+					resource.TestCheckResourceAttr(testResourceNameDynamicHostVolume, "capacity_max_bytes", "10737418240"),
+				),
+			},
+		},
+		CheckDestroy: testResourceDynamicHostVolume_checkDestroy(
+			testResourceNameDynamicHostVolume),
+	})
+}
+
 func testResourceDynamicHostVolume_config(name string) string {
 	return fmt.Sprintf(`
 resource "nomad_dynamic_host_volume" "test" {
@@ -121,6 +212,28 @@ resource "nomad_dynamic_host_volume" "test" {
 
 }
 `, name)
+}
+
+func testResourceDynamicHostVolume_capacityConfig(name, capacityMin, capacityMax string) string {
+	return fmt.Sprintf(`
+resource "nomad_dynamic_host_volume" "test" {
+  name      = "%s"
+  plugin_id = "mkdir"
+
+  capacity_min = "%s"
+  capacity_max = "%s"
+
+  capability {
+    access_mode     = "single-node-writer"
+    attachment_mode = "file-system"
+  }
+
+  constraint {
+    attribute = "$${attr.kernel.name}"
+    value     = "linux"
+  }
+}
+`, name, capacityMin, capacityMax)
 }
 
 func testResourceDynamicHostVolume_update(name string) string {


### PR DESCRIPTION
When updating a dynamic host volume with SDKv2, the planned config values (e.g. capacity_min, capacity_max) leak into Terraform state even when the API call fails. On subsequent refreshes, the Read function was conditionally skipping these fields, causing state to remain inconsistent.

Changes:
- Always set capacity_min and capacity_max from the API response in Read, ensuring state reflects the actual remote resource
- Add DiffSuppressFunc for capacity_min and capacity_max to suppress spurious diffs from equivalent byte representations (e.g. "1GiB" vs "1.0 GiB")
- Refactor dynamicHostVolumeRead into dynamicHostVolumeReadImpl with a flag to conditionally set capacity string fields, avoiding panics in the registration resource which lacks these schema fields

### Description

### Testing & Reproduction steps

**Setup:** A custom Nomad host volume plugin that rejects capacity changes:

```bash
#!/bin/bash
# no-resize plugin - rejects any size change on existing volumes
if [ "${curr_size}" -ne "${size}" ]; then
  echo "growing or shrinking the volume is not supported" >&2
  exit 1
fi
```

#### Reproduction (before fix):
1. Create a dynamic host volume:
``` terraform
resource "nomad_dynamic_host_volume" "test" {
  name         = "my-volume"
  plugin_id    = "no-resize"
  capacity_min = "1GiB"
  capacity_max = "1GiB"

  capability {
    access_mode     = "single-node-writer"
    attachment_mode = "file-system"
  }
}
```
2. Run `terraform apply` - succeeds, volume created at 1GiB.
3. Update `capacity_min = "2GiB"` and `capacity_max = "2GiB"`.
4. Run `terraform apply` - fails (plugin exits 1, rejects resize).
5. Run `terraform apply` again with the same 2GiB values - succeeds with no error and no changes. The state has the requested 2GiB values even though the volume is still 1GiB. Terraform believes the resource is in sync and never retries the update.

#### Expected behavior (after fix):
- Step 4: Apply fails. On next `terraform plan`/`terraform apply`, the refresh detects drift - state had stale "2GiB" from the failed apply, but the API reports "1.0 GiB". Terraform corrects the state.
- Step 5: Subsequent applies with 2GiB in config correctly show a diff (state "1.0 GiB" → config "2GiB") and attempt the update again (which will fail again from the plugin).

#### Verifying diff suppression for equivalent formats

1. Create a volume with capacity_min = "1GiB".
2. Change config to capacity_min = "1.0 GiB" or capacity_min = "1024MiB".
3. Run `terraform plan` - should show no changes (same byte value).

<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

Fixes: #619
Fixes: https://hashicorp.atlassian.net/browse/NMD-1425