### PR TITLE
resource/nomad_job: add preserve_resources argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ IMPROVEMENTS:
 * resource/nomad_csi_volume: migrate to Plugin Framework and add write-only attributes `secrets_wo` and `secrets_wo_version` to avoid storing secrets in state. ([#628](https://github.com/hashicorp/terraform-provider-nomad/pull/628))
 * resource/nomad_csi_volume_registration: migrate to Plugin Framework and add write-only attributes `secrets_wo` and `secrets_wo_version` to avoid storing secrets in state. ([#628](https://github.com/hashicorp/terraform-provider-nomad/pull/628))
 * resource/nomad_sentinel_policy: add `submit-host-volume` and `submit-csi-volume` scope support. ([#624](https://github.com/hashicorp/terraform-provider-nomad/pull/624))
+* resource/nomad_job: add `preserve_resources` argument to preserve task resources during job updates. ([#632](https://github.com/hashicorp/terraform-provider-nomad/pull/632))
 
 BUG FIXES:
 * data source/nomad_variable: Fix panic when reading a variable due to `items_wo_version` not being in the data source schema. ([#625](https://github.com/hashicorp/terraform-provider-nomad/pull/625))

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -63,6 +63,13 @@ func resourceJob() *schema.Resource {
 				Type:        schema.TypeBool,
 			},
 
+			"preserve_resources": {
+				Description: "If true, preserve the current task resources during job registration instead of using the resources from the jobspec.",
+				Optional:    true,
+				Default:     false,
+				Type:        schema.TypeBool,
+			},
+
 			"deregister_on_destroy": {
 				Description: "If true, the job will be deregistered on destroy.",
 				Optional:    true,
@@ -550,10 +557,11 @@ func resourceJobRegister(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	resp, _, err := client.Jobs().RegisterOpts(job, &api.RegisterOptions{
-		PolicyOverride: d.Get("policy_override").(bool),
-		PreserveCounts: d.Get("preserve_counts").(bool),
-		ModifyIndex:    wantModifyIndex,
-		Submission:     sub,
+		PolicyOverride:    d.Get("policy_override").(bool),
+		PreserveCounts:    d.Get("preserve_counts").(bool),
+		PreserveResources: d.Get("preserve_resources").(bool),
+		ModifyIndex:       wantModifyIndex,
+		Submission:        sub,
 	}, &api.WriteOptions{
 		Namespace: *job.Namespace,
 	})

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -97,6 +98,43 @@ func TestResourceJob_preserveCounts(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "task_groups.0.count", "3"),
 					resource.TestCheckResourceAttr(resourcePath, "priority", "75"),
 					testResourceJob_checkTaskGroupCount(jobID, groupName, 3),
+				),
+			},
+		},
+
+		CheckDestroy: testResourceJob_checkDestroy(jobID),
+	})
+}
+
+func TestResourceJob_preserveResources(t *testing.T) {
+	const resourcePath = "nomad_job.test"
+	const jobID = "foo-preserve-resources"
+	const groupName = "foo"
+	const taskName = "server"
+
+	r.Test(t, r.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []r.TestStep{
+			{
+				// Initial apply with preserve_resources = false registers the
+				// jobspec resources (cpu = 100, memory = 32).
+				Config: testResourceJob_preserveResourcesConfig(jobID, false, 50),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "priority", "50"),
+					testResourceJob_checkTaskResources(t, jobID, groupName, taskName, 100, 32),
+				),
+			},
+			{
+				// Simulate an external actor (e.g. the autoscaler) bumping the
+				// running task's resources out-of-band, then re-apply with
+				// preserve_resources = true. Nomad must keep the out-of-band
+				// resources (250/64) instead of resetting to the jobspec (100/32).
+				PreConfig: testResourceJob_updateTaskResources(t, jobID, groupName, taskName, 250, 64),
+				Config:    testResourceJob_preserveResourcesConfig(jobID, true, 75),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "priority", "75"),
+					testResourceJob_checkTaskResources(t, jobID, groupName, taskName, 250, 64),
 				),
 			},
 		},
@@ -2383,6 +2421,88 @@ func testResourceJob_scaleTaskGroup(t *testing.T, jobID, groupName string, count
 	}
 }
 
+// testResourceJob_updateTaskResources re-registers the job out-of-band with new
+// task resources, simulating a change made by an external actor such as the
+// Nomad autoscaler.
+func testResourceJob_updateTaskResources(t *testing.T, jobID, groupName, taskName string, cpu, memory int) func() {
+	return func() {
+		t.Helper()
+
+		providerConfig := testProvider.Meta().(ProviderConfig)
+		client := providerConfig.client
+
+		job, _, err := client.Jobs().Info(jobID, nil)
+		must.NoError(t, err)
+		must.NotNil(t, job)
+
+		var task *api.Task
+		for _, tg := range job.TaskGroups {
+			if tg == nil || tg.Name == nil || *tg.Name != groupName {
+				continue
+			}
+			for _, tk := range tg.Tasks {
+				if tk.Name == taskName {
+					task = tk
+					break
+				}
+			}
+		}
+		must.NotNil(t, task, must.Sprintf("task %q not found in group %q", taskName, groupName))
+
+		if task.Resources == nil {
+			task.Resources = &api.Resources{}
+		}
+		task.Resources.CPU = pointer.Of(cpu)
+		task.Resources.MemoryMB = pointer.Of(memory)
+
+		namespace := "default"
+		if job.Namespace != nil && *job.Namespace != "" {
+			namespace = *job.Namespace
+		}
+
+		resp, _, err := client.Jobs().Register(job, &api.WriteOptions{Namespace: namespace})
+		must.NoError(t, err)
+		must.NotNil(t, resp)
+
+		if resp.EvalID != "" {
+			_, err = monitorDeployment(context.Background(), client, 2*time.Minute, namespace, resp.EvalID)
+			must.NoError(t, err)
+		}
+	}
+}
+
+// testResourceJob_checkTaskResources queries Nomad directly and asserts the
+// running task has the expected cpu and memory resources.
+func testResourceJob_checkTaskResources(t *testing.T, jobID, groupName, taskName string, expectedCPU, expectedMemory int) r.TestCheckFunc {
+	return func(*terraform.State) error {
+		providerConfig := testProvider.Meta().(ProviderConfig)
+		client := providerConfig.client
+
+		job, _, err := client.Jobs().Info(jobID, nil)
+		must.NoError(t, err, must.Sprint("error reading back job"))
+
+		for _, tg := range job.TaskGroups {
+			if tg == nil || tg.Name == nil || *tg.Name != groupName {
+				continue
+			}
+			for _, tk := range tg.Tasks {
+				if tk.Name != taskName {
+					continue
+				}
+				must.NotNil(t, tk.Resources, must.Sprintf("task %q has nil resources", taskName))
+				must.NotNil(t, tk.Resources.CPU, must.Sprintf("task %q has nil cpu", taskName))
+				must.Eq(t, expectedCPU, *tk.Resources.CPU, must.Sprintf("task %q cpu mismatch", taskName))
+				must.NotNil(t, tk.Resources.MemoryMB, must.Sprintf("task %q has nil memory", taskName))
+				must.Eq(t, expectedMemory, *tk.Resources.MemoryMB, must.Sprintf("task %q memory mismatch", taskName))
+				return nil
+			}
+		}
+
+		t.Fatalf("task %q not found in group %q", taskName, groupName)
+		return nil
+	}
+}
+
 func testResourceJob_checkDestroy(jobID string) r.TestCheckFunc {
 	return testResourceJob_checkDestroyNS(jobID, "default")
 }
@@ -2573,6 +2693,42 @@ EOT
 	preserve_counts = %t
 }
 `, jobID, priority, groupName, preserveCounts)
+}
+
+func testResourceJob_preserveResourcesConfig(jobID string, preserveResources bool, priority int) string {
+	const groupName = "foo"
+
+	return fmt.Sprintf(`
+resource "nomad_job" "test" {
+	jobspec = <<EOT
+job %q {
+	datacenters = ["dc1"]
+	type        = "service"
+	priority    = %d
+
+	group %q {
+		count = 1
+
+		task "server" {
+			driver = "raw_exec"
+
+			config {
+				command = "/bin/sleep"
+				args    = ["60"]
+			}
+
+			resources {
+				cpu    = 100
+				memory = 32
+			}
+		}
+	}
+}
+EOT
+	detach = false
+	preserve_resources = %t
+}
+`, jobID, priority, groupName, preserveResources)
 }
 
 func testResourceJob_policyOverrideConfig() string {

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -261,6 +261,10 @@ The following arguments are supported:
   group counts already stored in Nomad during job registration instead of
   applying the counts from the submitted jobspec.
 
+- `preserve_resources` `(boolean: false)` - If true, preserves the current task
+  resources already stored in Nomad during job registration instead of
+  applying the resources from the submitted jobspec.
+
 - `json` `(boolean: false)` - Set this to `true` if your jobspec is structured with
   JSON instead of the default HCL.
 


### PR DESCRIPTION
Support the Nomad API's PreserveResources register option via a new preserve_resources argument. Includes docs update and acceptance test.

### Description

Adds a `preserve_resources` argument to the `nomad_job` resource. When set to true, the provider passes the Nomad API's `PreserveResources` register option, so that task resources (cpu/memory) already running in the cluster are preserved during a job update instead of being reset to the values in the jobspec.

### Testing & Reproduction steps
1. `terraform init`
2. Register a job
```hcl
job "demo" {
  datacenters = ["dc1"]
  group "api" {
    task "server" {
      driver = "raw_exec"
      config { command = "/bin/sleep"; args = ["600"] }
      resources { cpu = 100; memory = 32 }
    }
  }
}
```

```hcl
resource "nomad_job" "demo" {
  jobspec            = file("job.nomad")
}
```
3. Simulate an out-of-band change to job's task-group resources
4. `terraform apply` with `preserve_resources` set
```hcl
resource "nomad_job" "demo" {
  preserve_resources = true
  jobspec            = file("job.nomad")
}
```

<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

JIRA Ticket: https://hashicorp.atlassian.net/browse/NMD-1575

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.
