### PR TITLE
copyright headers

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -5,7 +5,7 @@ schema_version = 1
 
 project {
   license        = "MPL-2.0"
-  copyright_year = 2024
+  copyright_year = 2016
 
   header_ignore = [
     # changie tooling configuration and CHANGELOG entries (prose)

--- a/internal/framework/provider/acl/ephemeral_acl_token.go
+++ b/internal/framework/provider/acl/ephemeral_acl_token.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package acl

--- a/internal/framework/provider/acl/ephemeral_acl_token_test.go
+++ b/internal/framework/provider/acl/ephemeral_acl_token_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2026
+// Copyright IBM Corp. 2016, 2026
 
 package acl_test
 

--- a/internal/framework/provider/acl/ephemeral_intro_token.go
+++ b/internal/framework/provider/acl/ephemeral_intro_token.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package acl

--- a/internal/framework/provider/acl/ephemeral_intro_token_test.go
+++ b/internal/framework/provider/acl/ephemeral_intro_token_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2026
+// Copyright IBM Corp. 2016, 2026
 
 package acl_test
 

--- a/internal/framework/provider/acl/resource_acl_auth_method.go
+++ b/internal/framework/provider/acl/resource_acl_auth_method.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package acl

--- a/internal/framework/provider/acl/resource_acl_auth_method_test.go
+++ b/internal/framework/provider/acl/resource_acl_auth_method_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package acl_test

--- a/internal/framework/provider/acl/resource_acl_binding_rule.go
+++ b/internal/framework/provider/acl/resource_acl_binding_rule.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package acl

--- a/internal/framework/provider/acl/resource_acl_binding_rule_test.go
+++ b/internal/framework/provider/acl/resource_acl_binding_rule_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package acl_test

--- a/internal/framework/provider/provider.go
+++ b/internal/framework/provider/provider.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/framework/provider/testutil/helpers.go
+++ b/internal/framework/provider/testutil/helpers.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2026
+// Copyright IBM Corp. 2016, 2026
 
 package testutil
 

--- a/internal/framework/provider/variables/ephemeral_variable.go
+++ b/internal/framework/provider/variables/ephemeral_variable.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package variables

--- a/internal/framework/provider/variables/ephemeral_variable_test.go
+++ b/internal/framework/provider/variables/ephemeral_variable_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017, 2026
+// Copyright IBM Corp. 2016, 2026
 
 package variables_test
 

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package mux

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package mux

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package main

--- a/nomad/data_source_acl_policies.go
+++ b/nomad/data_source_acl_policies.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_acl_policies_test.go
+++ b/nomad/data_source_acl_policies_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_acl_policy_test.go
+++ b/nomad/data_source_acl_policy_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_acl_role_test.go
+++ b/nomad/data_source_acl_role_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_acl_roles_test.go
+++ b/nomad/data_source_acl_roles_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_acl_token.go
+++ b/nomad/data_source_acl_token.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_acl_token_test.go
+++ b/nomad/data_source_acl_token_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_acl_tokens_test.go
+++ b/nomad/data_source_acl_tokens_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_allocations_test.go
+++ b/nomad/data_source_allocations_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_datacenters.go
+++ b/nomad/data_source_datacenters.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_datacenters_test.go
+++ b/nomad/data_source_datacenters_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_deployments_test.go
+++ b/nomad/data_source_deployments_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_dynamic_host_volume.go
+++ b/nomad/data_source_dynamic_host_volume.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_job_parser.go
+++ b/nomad/data_source_job_parser.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_job_parser_test.go
+++ b/nomad/data_source_job_parser_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_jwks.go
+++ b/nomad/data_source_jwks.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_jwks_test.go
+++ b/nomad/data_source_jwks_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_namespace.go
+++ b/nomad/data_source_namespace.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_namespace_test.go
+++ b/nomad/data_source_namespace_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_namespaces_test.go
+++ b/nomad/data_source_namespaces_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_node.go
+++ b/nomad/data_source_node.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_node_pool.go
+++ b/nomad/data_source_node_pool.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_node_pool_test.go
+++ b/nomad/data_source_node_pool_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_node_pools.go
+++ b/nomad/data_source_node_pools.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_node_pools_test.go
+++ b/nomad/data_source_node_pools_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_node_test.go
+++ b/nomad/data_source_node_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_nodes.go
+++ b/nomad/data_source_nodes.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_nodes_test.go
+++ b/nomad/data_source_nodes_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_regions_test.go
+++ b/nomad/data_source_regions_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_scaling_policies.go
+++ b/nomad/data_source_scaling_policies.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_scaling_policies_test.go
+++ b/nomad/data_source_scaling_policies_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_scaling_policy_test.go
+++ b/nomad/data_source_scaling_policy_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_scheduler_config.go
+++ b/nomad/data_source_scheduler_config.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_variable.go
+++ b/nomad/data_source_variable.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/data_source_variable_test.go
+++ b/nomad/data_source_variable_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/datasource_nomad_job.go
+++ b/nomad/datasource_nomad_job.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/datasource_nomad_job_test.go
+++ b/nomad/datasource_nomad_job_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/datasource_nomad_plugin.go
+++ b/nomad/datasource_nomad_plugin.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/provider_test.go
+++ b/nomad/provider_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_acl_policy.go
+++ b/nomad/resource_acl_policy.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_acl_policy_test.go
+++ b/nomad/resource_acl_policy_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_acl_role_test.go
+++ b/nomad/resource_acl_role_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_acl_token.go
+++ b/nomad/resource_acl_token.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_acl_token_test.go
+++ b/nomad/resource_acl_token_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_dynamic_host_volume.go
+++ b/nomad/resource_dynamic_host_volume.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_dynamic_host_volume_registration_test.go
+++ b/nomad/resource_dynamic_host_volume_registration_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_dynamic_host_volume_test.go
+++ b/nomad/resource_dynamic_host_volume_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_external_volume_test.go
+++ b/nomad/resource_external_volume_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_namespace.go
+++ b/nomad/resource_namespace.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_namespace_test.go
+++ b/nomad/resource_namespace_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_node_pool.go
+++ b/nomad/resource_node_pool.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_node_pool_test.go
+++ b/nomad/resource_node_pool_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_quota_specification.go
+++ b/nomad/resource_quota_specification.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_quota_specification_test.go
+++ b/nomad/resource_quota_specification_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_scheduler_config_test.go
+++ b/nomad/resource_scheduler_config_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_sentinel_policy.go
+++ b/nomad/resource_sentinel_policy.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_sentinel_policy_test.go
+++ b/nomad/resource_sentinel_policy_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_variable.go
+++ b/nomad/resource_variable.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/nomad/resource_variable_test.go
+++ b/nomad/resource_variable_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package nomad

--- a/scripts/getnomad.sh
+++ b/scripts/getnomad.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2016, 2025
+# Copyright IBM Corp. 2016, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/scripts/start-nomad.sh
+++ b/scripts/start-nomad.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2016, 2025
+# Copyright IBM Corp. 2016, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 set -e


### PR DESCRIPTION
The updated version of copywrite needs a different base year, pointing to the first commit (2016 in this repo). Update the config and run `copywrite headers` to update headers that are stale


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.
