### PR TITLE
Add extra_claims support to namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/nomad v1.11.3
-	github.com/hashicorp/nomad/api v0.0.0-20260408063511-b0f552dbe971
+	github.com/hashicorp/nomad/api v0.0.0-20260603170129-f069a7c814c7
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/nomad v1.11.3 h1:u16fs0X1BGXyD0q4wIG2VSIZ0rbtrHj7+KcayGQv9JY=
 github.com/hashicorp/nomad v1.11.3/go.mod h1:LnGz6+ktjHW6828q6EMFDY2N4pbHvT32yudY7iKMQGo=
-github.com/hashicorp/nomad/api v0.0.0-20260408063511-b0f552dbe971 h1:UCu7VUBDCIm7YPcY6Lf2986Xw5GgNaQEXnvgdvlD8zA=
-github.com/hashicorp/nomad/api v0.0.0-20260408063511-b0f552dbe971/go.mod h1:KkLNLU0Nyfh5jWsFoF/PsmMbKpRIAoIV4lmQoJWgKCk=
+github.com/hashicorp/nomad/api v0.0.0-20260603170129-f069a7c814c7 h1:vYXWYEQrYqMdNkpuCKFoELeq72jjXltXqqk86klMSjc=
+github.com/hashicorp/nomad/api v0.0.0-20260603170129-f069a7c814c7/go.mod h1:Kr8imJwigbQ/50BqVae2+JL+AyX+FnzbnuCoIFb6iYg=
 github.com/hashicorp/terraform-exec v0.25.1 h1:PRutYRGM8pixV3B8812NYoBK5O+yuf3qcB/70KFKGiU=
 github.com/hashicorp/terraform-exec v0.25.1/go.mod h1:+izOYrs9sKMQK4OYvGDnrSSJHY/pm4e4eXFqSL2Q5mA=
 github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoKST/tRDBJKU=

--- a/nomad/data_source_namespace.go
+++ b/nomad/data_source_namespace.go
@@ -33,6 +33,22 @@ func dataSourceNamespace() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"required_extra_claims": {
+				Description: "Additional workload identity claims provided as extra workload identity claims for every workload in this namespace.",
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"optional_extra_claims": {
+				Description: "Additional workload identity claims provided as optional extra workload identity claims for workloads in this namespace. The extra identity claims are only added if the jobspec includes them in its identity block.",
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"capabilities": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -139,6 +155,12 @@ func namespaceDataSourceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err = d.Set("meta", ns.Meta); err != nil {
 		return fmt.Errorf("Failed to set 'meta': %v", err)
+	}
+	if err = d.Set("required_extra_claims", ns.RequiredExtraClaims); err != nil {
+		return fmt.Errorf("Failed to set 'required_extra_claims': %v", err)
+	}
+	if err = d.Set("optional_extra_claims", ns.OptionalExtraClaims); err != nil {
+		return fmt.Errorf("Failed to set 'optional_extra_claims': %v", err)
 	}
 	if err = d.Set("capabilities", flattenNamespaceCapabilities(ns.Capabilities)); err != nil {
 		return fmt.Errorf("Failed to set 'capabilities': %v", err)

--- a/nomad/data_source_namespace_test.go
+++ b/nomad/data_source_namespace_test.go
@@ -52,6 +52,39 @@ func TestDataSourceNamespace(t *testing.T) {
 	})
 }
 
+func TestDataSourceNamespace_extraClaims(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-nomad-test")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "2.0.3") },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "nomad_namespace" "test" {
+  name = "%s"
+
+  required_extra_claims = {
+    namespace = "$${job.namespace}"
+  }
+
+  optional_extra_claims = {
+    class = "class:$${node.class}"
+  }
+}
+
+data "nomad_namespace" "test" {
+  name = nomad_namespace.test.name
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.nomad_namespace.test", "required_extra_claims.namespace", "${job.namespace}"),
+					resource.TestCheckResourceAttr("data.nomad_namespace.test", "optional_extra_claims.class", "class:${node.class}"),
+				),
+			},
+		},
+	})
+}
+
 func TestDataSourceNamespace_nodePoolConfig(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{

--- a/nomad/resource_namespace.go
+++ b/nomad/resource_namespace.go
@@ -54,6 +54,24 @@ func resourceNamespace() *schema.Resource {
 				},
 			},
 
+			"required_extra_claims": {
+				Description: "Additional workload identity claims provided as extra workload identity claims for every workload in this namespace.",
+				Optional:    true,
+				Type:        schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"optional_extra_claims": {
+				Description: "Additional workload identity claims provided as optional extra workload identity claims for workloads in this namespace. The extra identity claims are only added if the jobspec includes them in its identity block.",
+				Optional:    true,
+				Type:        schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
 			"capabilities": {
 				Description: "Capabilities of the namespace.",
 				Optional:    true,
@@ -223,9 +241,19 @@ func resourceNamespaceConsulConfig() *schema.Resource {
 func resourceNamespaceWrite(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(ProviderConfig).client
 
-	m := make(map[string]string)
+	metadata := make(map[string]string)
 	for name, value := range d.Get("meta").(map[string]interface{}) {
-		m[name] = value.(string)
+		metadata[name] = value.(string)
+	}
+
+	requiredExtraClaims := make(map[string]string)
+	for name, value := range d.Get("required_extra_claims").(map[string]interface{}) {
+		requiredExtraClaims[name] = value.(string)
+	}
+
+	optionalExtraClaims := make(map[string]string)
+	for name, value := range d.Get("optional_extra_claims").(map[string]interface{}) {
+		optionalExtraClaims[name] = value.(string)
 	}
 
 	capabilities, err := expandNamespaceCapabilities(d)
@@ -252,7 +280,9 @@ func resourceNamespaceWrite(d *schema.ResourceData, meta interface{}) error {
 		Name:                  d.Get("name").(string),
 		Description:           d.Get("description").(string),
 		Quota:                 d.Get("quota").(string),
-		Meta:                  m,
+		Meta:                  metadata,
+		RequiredExtraClaims:   requiredExtraClaims,
+		OptionalExtraClaims:   optionalExtraClaims,
 		Capabilities:          capabilities,
 		NodePoolConfiguration: npConfig,
 		VaultConfiguration:    vaultConfig,
@@ -281,6 +311,8 @@ func resourceNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
 			log.Printf("[DEBUG] Can't delete default namespace, clearing attributes instead")
 			d.Set("description", "Default shared namespace")
 			d.Set("quota", "")
+			d.Set("required_extra_claims", map[string]string{})
+			d.Set("optional_extra_claims", map[string]string{})
 			err = resourceNamespaceWrite(d, meta)
 		} else {
 			// make sure there are no quota specs associated with that namespace
@@ -334,6 +366,8 @@ func resourceNamespaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", namespace.Description)
 	d.Set("quota", namespace.Quota)
 	d.Set("meta", namespace.Meta)
+	d.Set("required_extra_claims", namespace.RequiredExtraClaims)
+	d.Set("optional_extra_claims", namespace.OptionalExtraClaims)
 	d.Set("capabilities", flattenNamespaceCapabilities(namespace.Capabilities))
 	d.Set("node_pool_config", flattenNamespaceNodePoolConfig(namespace.NodePoolConfiguration))
 	d.Set("vault_config", flattenNamespaceVaultConfig(namespace.VaultConfiguration))

--- a/nomad/resource_namespace_test.go
+++ b/nomad/resource_namespace_test.go
@@ -55,6 +55,43 @@ func TestResourceNamespace_basic(t *testing.T) {
 	})
 }
 
+func TestResourceNamespace_extraClaims(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-nomad-test")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "2.0.3") },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceNamespace_extraClaimsConfig(name, true),
+				Check: testResourceNamespace_extraClaimsCheck(name,
+					map[string]string{"namespace": "${job.namespace}"},
+					map[string]string{
+						"class":      "class:${node.class}",
+						"datacenter": "dc:${node.datacenter}",
+					},
+				),
+			},
+			{
+				Config: testResourceNamespace_extraClaimsConfig(name, false),
+				Check: testResourceNamespace_extraClaimsCheck(name,
+					map[string]string{
+						"namespace": "${job.namespace}",
+						"service":   "${task.name}",
+					},
+					nil,
+				),
+			},
+			{
+				ResourceName:      "nomad_namespace.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+
+		CheckDestroy: testResourceNamespace_checkDestroy(name),
+	})
+}
+
 func TestResourceNamespace_refresh(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-nomad-test")
 	resource.Test(t, resource.TestCase{
@@ -124,6 +161,27 @@ func TestResourceNamespace_deleteDefault(t *testing.T) {
 			{
 				Config: testResourceNamespace_initialConfig(name),
 				Check:  testResourceNamespace_initialCheck(name),
+			},
+		},
+
+		CheckDestroy: testResourceNamespace_checkResetDefault(),
+	})
+}
+
+func TestResourceNamespace_deleteDefaultExtraClaims(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t); testCheckMinVersion(t, "2.0.3") },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceNamespace_extraClaimsConfig(api.DefaultNamespace, true),
+				Check: testResourceNamespace_extraClaimsCheck(api.DefaultNamespace,
+					map[string]string{"namespace": "${job.namespace}"},
+					map[string]string{
+						"class":      "class:${node.class}",
+						"datacenter": "dc:${node.datacenter}",
+					},
+				),
 			},
 		},
 
@@ -231,6 +289,34 @@ resource "nomad_namespace" "test" {
   }
 }
 `, name)
+}
+
+func testResourceNamespace_extraClaimsConfig(name string, includeOptional bool) string {
+	requiredClaims := `    namespace = "$${job.namespace}"
+`
+	if !includeOptional {
+		requiredClaims += `    service = "$${task.name}"
+`
+	}
+
+	optionalClaims := ""
+	if includeOptional {
+		optionalClaims = `
+  optional_extra_claims = {
+    class      = "class:$${node.class}"
+    datacenter = "dc:$${node.datacenter}"
+  }
+`
+	}
+
+	return fmt.Sprintf(`
+resource "nomad_namespace" "test" {
+  name = "%s"
+
+  required_extra_claims = {
+%s  }
+%s}
+`, name, requiredClaims, optionalClaims)
 }
 
 func testResourceNamespace_configWithQuota(name, quota string) string {
@@ -387,6 +473,33 @@ func testResourceNamespace_checkResetDefault() resource.TestCheckFunc {
 		}
 		if namespace.Description != defaultNamespace.Description || namespace.Quota != defaultNamespace.Quota {
 			return fmt.Errorf("default namespace %q not reset.", defaultNamespace.Name)
+		}
+		if len(namespace.RequiredExtraClaims) != 0 || len(namespace.OptionalExtraClaims) != 0 {
+			return fmt.Errorf("default namespace %q extra claims not reset.", defaultNamespace.Name)
+		}
+
+		return nil
+	}
+}
+
+func testResourceNamespace_extraClaimsCheck(name string, required, optional map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["nomad_namespace.test"]
+		if resourceState == nil {
+			return errors.New("resource not found in state")
+		}
+
+		client := testProvider.Meta().(ProviderConfig).client
+		namespace, _, err := client.Namespaces().Info(name, nil)
+		if err != nil {
+			return fmt.Errorf("error reading back namespace %q: %w", name, err)
+		}
+
+		if diff := cmp.Diff(required, namespace.RequiredExtraClaims); diff != "" {
+			return fmt.Errorf("required extra claims mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(optional, namespace.OptionalExtraClaims); diff != "" {
+			return fmt.Errorf("optional extra claims mismatch (-want +got):\n%s", diff)
 		}
 
 		return nil

--- a/website/docs/d/namespace.html.markdown
+++ b/website/docs/d/namespace.html.markdown
@@ -29,6 +29,8 @@ The following attributes are exported:
 * `description` `(string)` - The description of the namespace.
 * `quota` `(string)` - The quota associated with the namespace.
 * `meta` `(map[string]string)` -  Arbitrary KV metadata associated with the namespace.
+* `required_extra_claims` `(map[string]string)` - Additional workload identity claims provided as extra workload identity claims for every workload in this namespace.
+* `optional_extra_claims` `(map[string]string)` - Additional workload identity claims provided as optional extra workload identity claims for workloads in this namespace. The extra identity claims are only added if the jobspec includes them in its identity block.
 * `capabilities` `(block)` - Capabilities of the namespace
   * `enabled_task_drivers` `([]string)` - Task drivers enabled for the namespace.
   * `disabled_task_drivers` `([]string)` - Task drivers disabled for the namespace.

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -63,6 +63,8 @@ The following arguments are supported:
 - `description` `(string: "")` - A description of the namespace.
 - `quota` `(string: "")` - A resource quota to attach to the namespace.
 - `meta` `(map[string]string: <optional>)` -  Specifies arbitrary KV metadata to associate with the namespace.
+- `required_extra_claims` `(map[string]string)` - Additional workload identity claims provided as extra workload identity claims for every workload in this namespace.
+- `optional_extra_claims` `(map[string]string)` - Additional workload identity claims provided as optional extra workload identity claims for workloads in this namespace. The extra identity claims are only added if the jobspec includes them in its identity block.
 - `capabilities` `(block: <optional>)` - A block of capabilities for the namespace. Can't
   be repeated. See below for the structure of this block.
 - `node_pool_config` `(block: <optional>)` - A block with node pool configuration for the namespace (Nomad Enterprise only).


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/27786 (released in [Nomad v2.0.3](https://github.com/hashicorp/nomad/releases/tag/v2.0.3)) added new configuration options to namespaces:
- [`required_extra_claims`](https://developer.hashicorp.com/nomad/docs/other-specifications/namespace#required_extra_claims)
- [`optional_extra_claims`](https://developer.hashicorp.com/nomad/docs/other-specifications/namespace#optional_extra_claims)

Both currently can not be managed through the Nomad Terraform provider. This PR adds the `required_extra_claims` and `optional_extra_claims` fields to both the `nomad_namespace` `data` and `resource`.

I've also added docs and tests for both fields.
